### PR TITLE
Feature(token): Remove default kyc property upon creation

### DIFF
--- a/hapi-proto/HAPI.html
+++ b/hapi-proto/HAPI.html
@@ -4837,7 +4837,7 @@ If unspecified, no change. </p></td>
                   <td>tokenId</td>
                   <td><a href="#proto.TokenID">TokenID</a></td>
                   <td></td>
-                  <td><p>The ID of the token, in the format that can be used for querying TokenInfo </p></td>
+                  <td><p>The ID of the token, in the format that can be used as TokenRef </p></td>
                 </tr>
               
                 <tr>
@@ -8712,13 +8712,6 @@ by HAPI.</p></td>
                   <td><a href="#bool">bool</a></td>
                   <td></td>
                   <td><p>The default Freeze status (frozen or unfrozen) of Hedera accounts relative to this token. If true, an account must be unfrozen before it can receive the token </p></td>
-                </tr>
-              
-                <tr>
-                  <td>kycDefault</td>
-                  <td><a href="#bool">bool</a></td>
-                  <td></td>
-                  <td><p>The default KYC status (granted or revoked) of Hedera accounts relative to this token. If true, an account must be KYCed before it can receive the token. If false or empty KYC is not required. </p></td>
                 </tr>
               
                 <tr>

--- a/hapi-proto/HAPI.html
+++ b/hapi-proto/HAPI.html
@@ -8683,7 +8683,7 @@ by HAPI.</p></td>
                   <td>kycKey</td>
                   <td><a href="#proto.Key">Key</a></td>
                   <td></td>
-                  <td><p>The key which can grant or revoke KYC of an account for the token&#39;s transactions. If empty, KYC grant or revoke is not possible </p></td>
+                  <td><p>The key which can grant or revoke KYC of an account for the token&#39;s transactions. If empty, KYC grant is given to every account, and KYC grant or revoke to an account is not possible. </p></td>
                 </tr>
               
                 <tr>

--- a/hapi-proto/src/main/proto/TokenCreate.proto
+++ b/hapi-proto/src/main/proto/TokenCreate.proto
@@ -48,7 +48,6 @@ message TokenCreateTransactionBody {
     Key wipeKey = 9; // The key which can wipe the token balance of an account. If empty, wipe is not possible
     Key supplyKey = 10; // The key which can change the supply of a token, meaning that this key is required for Token Mint/Burn operations
     bool freezeDefault = 11; // The default Freeze status (frozen or unfrozen) of Hedera accounts relative to this token. If true, an account must be unfrozen before it can receive the token
-    bool kycDefault = 12; // The default KYC status (granted or revoked) of Hedera accounts relative to this token. If true, an account must be KYCed before it can receive the token. If false or empty KYC is not required.
     uint64 expiry = 13; // The epoch second at which the the token should expiry; if an auto-renew account and period are specified, this is coerced to the current epoch second plus the autoRenewPeriod
     AccountID autoRenewAccount = 14; // An account which will be automatically charged to renew the token's expiration, at an interval given by the autoRenewPeriod below
     uint64 autoRenewPeriod = 15; // The interval at which the auto-renew account will be charged to extend the token's expiry

--- a/hapi-proto/src/main/proto/TokenCreate.proto
+++ b/hapi-proto/src/main/proto/TokenCreate.proto
@@ -43,7 +43,7 @@ message TokenCreateTransactionBody {
     uint64 initialSupply = 4; // Specifies the initial supply of tokens to be put in circulation. The initial supply is sent to the Treasury Account
     AccountID treasury = 5; // The account which will act as a treasury for the token. This account will receive the specified initial supply
     Key adminKey = 6; // The key which can perform update operations on the token. If empty, the token can be perceived as immutable (not being able to be updated)
-    Key kycKey = 7; // The key which can grant or revoke KYC of an account for the token's transactions. If empty, KYC grant or revoke is not possible
+    Key kycKey = 7; // The key which can grant or revoke KYC of an account for the token's transactions. If empty, KYC grant is given to every account, and KYC grant or revoke to an account is not possible.
     Key freezeKey = 8; // The key which can sign to freeze or unfreeze an account for token transactions. If empty, freezing is not possible
     Key wipeKey = 9; // The key which can wipe the token balance of an account. If empty, wipe is not possible
     Key supplyKey = 10; // The key which can change the supply of a token, meaning that this key is required for Token Mint/Burn operations

--- a/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/primitives/StateView.java
@@ -184,7 +184,7 @@ public class StateView {
 
 			var kycCandidate = token.kycKey();
 			kycCandidate.ifPresentOrElse(k -> {
-				info.setDefaultKycStatus(tksFor(token.accountKycGrantedByDefault()));
+				info.setDefaultKycStatus(tksFor(token.accountsKycGrantedByDefault()));
 				info.setKycKey(asKeyUnchecked(k));
 			}, () -> info.setDefaultKycStatus(TokenKycStatus.KycNotApplicable));
 

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccountState.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleAccountState.java
@@ -424,7 +424,7 @@ public class MerkleAccountState extends AbstractMerkleNode implements MerkleLeaf
 			return true;
 		}
 		int i = logicalIndexOf(id);
-		return (i < 0) ? token.accountKycGrantedByDefault() : isKycGranted(i);
+		return (i < 0) ? token.accountsKycGrantedByDefault() : isKycGranted(i);
 	}
 
 	public void freeze(TokenID id, MerkleToken token) {
@@ -451,7 +451,7 @@ public class MerkleAccountState extends AbstractMerkleNode implements MerkleLeaf
 		if (token.kycKey().isEmpty()) {
 			return;
 		}
-		long defaultForNewRel = token.accountKycGrantedByDefault()
+		long defaultForNewRel = token.accountsKycGrantedByDefault()
 				? NOOP_MASK
 				: KYC_MASK | defaultFreezeMaskFor(token);
 		updateFlag(KYC_MASK, defaultForNewRel, id, this::set);
@@ -461,7 +461,7 @@ public class MerkleAccountState extends AbstractMerkleNode implements MerkleLeaf
 		if (token.kycKey().isEmpty()) {
 			return;
 		}
-		long defaultForNewRel = !token.accountKycGrantedByDefault()
+		long defaultForNewRel = !token.accountsKycGrantedByDefault()
 				? NOOP_MASK
 				: defaultFreezeMaskFor(token);
 		updateFlag(KYC_MASK, defaultForNewRel, id, this::unset);
@@ -470,7 +470,7 @@ public class MerkleAccountState extends AbstractMerkleNode implements MerkleLeaf
 	public ResponseCodeEnum validityOfAdjustment(TokenID id, MerkleToken token, long adjustment) {
 		int i = logicalIndexOf(id), at = i;
 		if (i < 0) {
-			if (!token.accountKycGrantedByDefault()) {
+			if (!token.accountsKycGrantedByDefault()) {
 				return ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN;
 			}
 			if (token.accountsAreFrozenByDefault()) {
@@ -499,7 +499,7 @@ public class MerkleAccountState extends AbstractMerkleNode implements MerkleLeaf
 			if (adjustment < 0) {
 				throwBalanceIse(id, adjustment);
 			}
-			if (!token.accountKycGrantedByDefault()) {
+			if (!token.accountsKycGrantedByDefault()) {
 				throwNoKycIse(id);
 			}
 			if (token.accountsAreFrozenByDefault()) {
@@ -606,7 +606,7 @@ public class MerkleAccountState extends AbstractMerkleNode implements MerkleLeaf
 	}
 
 	private long defaultKycMaskFor(MerkleToken token) {
-		var flag = !token.hasKycKey() || token.accountKycGrantedByDefault();
+		var flag = !token.hasKycKey() || token.accountsKycGrantedByDefault();
 		return flag ? KYC_MASK : 0;
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleToken.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleToken.java
@@ -66,7 +66,7 @@ public class MerkleToken extends AbstractMerkleNode implements FCMValue, MerkleL
 	private String name;
 	private boolean deleted;
 	private boolean accountsFrozenByDefault;
-	private boolean accountKycGrantedByDefault;
+	private boolean accountsKycGrantedByDefault;
 	private EntityId treasury;
 	private EntityId autoRenewAccount = UNUSED_AUTO_RENEW_ACCOUNT;
 
@@ -97,7 +97,7 @@ public class MerkleToken extends AbstractMerkleNode implements FCMValue, MerkleL
 		this.symbol = symbol;
 		this.name = name;
 		this.accountsFrozenByDefault = accountsFrozenByDefault;
-		this.accountKycGrantedByDefault = accountKycGrantedByDefault;
+		this.accountsKycGrantedByDefault = accountKycGrantedByDefault;
 		this.treasury = treasury;
 	}
 
@@ -118,7 +118,7 @@ public class MerkleToken extends AbstractMerkleNode implements FCMValue, MerkleL
 				this.tokenFloat == that.tokenFloat &&
 				this.divisibility == that.divisibility &&
 				this.accountsFrozenByDefault == that.accountsFrozenByDefault &&
-				this.accountKycGrantedByDefault == that.accountKycGrantedByDefault &&
+				this.accountsKycGrantedByDefault == that.accountsKycGrantedByDefault &&
 				Objects.equals(this.symbol, that.symbol) &&
 				Objects.equals(this.name, that.name) &&
 				Objects.equals(this.treasury, that.treasury) &&
@@ -145,7 +145,7 @@ public class MerkleToken extends AbstractMerkleNode implements FCMValue, MerkleL
 				symbol,
 				name,
 				accountsFrozenByDefault,
-				accountKycGrantedByDefault,
+				accountsKycGrantedByDefault,
 				treasury,
 				autoRenewAccount,
 				autoRenewPeriod);
@@ -169,7 +169,7 @@ public class MerkleToken extends AbstractMerkleNode implements FCMValue, MerkleL
 				.add("wipeKey", describe(wipeKey))
 				.add("supplyKey", describe(supplyKey))
 				.add("freezeKey", describe(freezeKey))
-				.add("accountKycGrantedByDefault", accountKycGrantedByDefault)
+				.add("accountsKycGrantedByDefault", accountsKycGrantedByDefault)
 				.add("accountsFrozenByDefault", accountsFrozenByDefault)
 				.toString();
 	}
@@ -201,7 +201,7 @@ public class MerkleToken extends AbstractMerkleNode implements FCMValue, MerkleL
 		tokenFloat = in.readLong();
 		divisibility = in.readInt();
 		accountsFrozenByDefault = in.readBoolean();
-		accountKycGrantedByDefault = in.readBoolean();
+		accountsKycGrantedByDefault = in.readBoolean();
 		adminKey = serdes.readNullable(in, serdes::deserializeKey);
 		freezeKey = serdes.readNullable(in, serdes::deserializeKey);
 		kycKey = serdes.readNullable(in, serdes::deserializeKey);
@@ -221,7 +221,7 @@ public class MerkleToken extends AbstractMerkleNode implements FCMValue, MerkleL
 		out.writeLong(tokenFloat);
 		out.writeInt(divisibility);
 		out.writeBoolean(accountsFrozenByDefault);
-		out.writeBoolean(accountKycGrantedByDefault);
+		out.writeBoolean(accountsKycGrantedByDefault);
 		serdes.writeNullable(adminKey, out, serdes::serializeKey);
 		serdes.writeNullable(freezeKey, out, serdes::serializeKey);
 		serdes.writeNullable(kycKey, out, serdes::serializeKey);
@@ -239,7 +239,7 @@ public class MerkleToken extends AbstractMerkleNode implements FCMValue, MerkleL
 				symbol,
 				name,
 				accountsFrozenByDefault,
-				accountKycGrantedByDefault,
+				accountsKycGrantedByDefault,
 				treasury);
 		fc.setDeleted(deleted);
 		fc.setAutoRenewPeriod(autoRenewPeriod);
@@ -367,8 +367,8 @@ public class MerkleToken extends AbstractMerkleNode implements FCMValue, MerkleL
 		return accountsFrozenByDefault;
 	}
 
-	public boolean accountKycGrantedByDefault() {
-		return accountKycGrantedByDefault;
+	public boolean accountsKycGrantedByDefault() {
+		return accountsKycGrantedByDefault;
 	}
 
 	public EntityId treasury() {
@@ -415,7 +415,7 @@ public class MerkleToken extends AbstractMerkleNode implements FCMValue, MerkleL
 		this.accountsFrozenByDefault = accountsFrozenByDefault;
 	}
 
-	void setAccountKycGrantedByDefault(boolean accountKycGrantedByDefault) {
-		this.accountKycGrantedByDefault = accountKycGrantedByDefault;
+	void setAccountsKycGrantedByDefault(boolean accountKycGrantedByDefault) {
+		this.accountsKycGrantedByDefault = accountKycGrantedByDefault;
 	}
 }

--- a/hedera-node/src/main/java/com/hedera/services/tokens/HederaTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/tokens/HederaTokenStore.java
@@ -229,7 +229,7 @@ public class HederaTokenStore implements TokenStore {
 				value,
 				TOKEN_HAS_NO_KYC_KEY,
 				IS_KYC_GRANTED,
-				MerkleToken::accountKycGrantedByDefault,
+				MerkleToken::accountsKycGrantedByDefault,
 				MerkleToken::kycKey);
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/tokens/HederaTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/tokens/HederaTokenStore.java
@@ -394,7 +394,7 @@ public class HederaTokenStore implements TokenStore {
 				request.getSymbol(),
 				request.getName(),
 				request.getFreezeDefault(),
-				kycKey.isEmpty() || request.getKycDefault(),
+				kycKey.isEmpty(),
 				ofNullableAccountId(request.getTreasury()));
 		adminKey.ifPresent(pendingCreation::setAdminKey);
 		kycKey.ifPresent(pendingCreation::setKycKey);

--- a/hedera-node/src/test/java/com/hedera/services/sigs/metadata/DelegatingSigMetadataLookupTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/sigs/metadata/DelegatingSigMetadataLookupTest.java
@@ -49,7 +49,7 @@ class DelegatingSigMetadataLookupTest {
 	int divisibility = 2;
 	long tokenFloat = 1_000_000;
 	boolean freezeDefault = true;
-	boolean kycDefault = true;
+	boolean accountsKycGrantedByDefault = true;
 	EntityId treasury = new EntityId(1,2, 3);
 	TokenRef ref = IdUtils.asIdRef("1.2.666");
 
@@ -63,7 +63,7 @@ class DelegatingSigMetadataLookupTest {
 		adminKey = new JEd25519Key("not-a-real-admin-key".getBytes());
 		freezeKey = new JEd25519Key("not-a-real-freeze-key".getBytes());
 
-		token = new MerkleToken(Long.MAX_VALUE, tokenFloat, divisibility, symbol, tokenName,  freezeDefault, kycDefault, treasury);
+		token = new MerkleToken(Long.MAX_VALUE, tokenFloat, divisibility, symbol, tokenName,  freezeDefault, accountsKycGrantedByDefault, treasury);
 
 		tokenStore = mock(TokenStore.class);
 

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountStateTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleAccountStateTest.java
@@ -269,7 +269,7 @@ class MerkleAccountStateTest {
 	@Test
 	public void willNotSetNewBalanceIfTokenFreezesByDefault() {
 		// given:
-		unusableAtFirst.setAccountKycGrantedByDefault(true);
+		unusableAtFirst.setAccountsKycGrantedByDefault(true);
 		// and:
 		var result = subject.validityOfAdjustment(
 				tokenWith(firstToken - 1), unusableAtFirst, firstBalance + 1);
@@ -336,7 +336,7 @@ class MerkleAccountStateTest {
 	@Test
 	public void unfreezeCreatesRelationshipIfTokenFreezesByDefault() {
 		// given:
-		unusableAtFirst.setAccountKycGrantedByDefault(true);
+		unusableAtFirst.setAccountsKycGrantedByDefault(true);
 
 		// when:
 		subject.unfreeze(tokenWith(firstToken - 1), unusableAtFirst);
@@ -407,7 +407,7 @@ class MerkleAccountStateTest {
 	@Test
 	public void grantKycIsNoopForNewRelWithDefaultKycToken() {
 		// given:
-		unusableAtFirst.setAccountKycGrantedByDefault(true);
+		unusableAtFirst.setAccountsKycGrantedByDefault(true);
 
 		// when:
 		subject.grantKyc(tokenWith(firstToken - 1), unusableAtFirst);
@@ -419,7 +419,7 @@ class MerkleAccountStateTest {
 	@Test
 	public void unfreezeForDefaultFrozenUsesCorrectKycStatusSafely() {
 		// given:
-		unusableAtFirst.setAccountKycGrantedByDefault(false);
+		unusableAtFirst.setAccountsKycGrantedByDefault(false);
 		unusableAtFirst.setKycKey(MerkleToken.UNUSED_KEY);
 
 		// when:
@@ -433,7 +433,7 @@ class MerkleAccountStateTest {
 	public void freezeForDefaultUnfrozenUsesCorrectKycStatusSafely() {
 		// given:
 		unusableAtFirst.setAccountsFrozenByDefault(false);
-		unusableAtFirst.setAccountKycGrantedByDefault(false);
+		unusableAtFirst.setAccountsKycGrantedByDefault(false);
 		unusableAtFirst.setKycKey(MerkleToken.UNUSED_KEY);
 
 		// when:
@@ -446,7 +446,7 @@ class MerkleAccountStateTest {
 	@Test
 	public void revokeKycForDefaultGrantedUsesCorrectFreezeStatus() {
 		// given:
-		unusableAtFirst.setAccountKycGrantedByDefault(true);
+		unusableAtFirst.setAccountsKycGrantedByDefault(true);
 
 		// when:
 		subject.revokeKyc(tokenWith(firstToken - 1), unusableAtFirst);
@@ -458,7 +458,7 @@ class MerkleAccountStateTest {
 	@Test
 	public void revokeKycForDefaultGrantedUsesCorrectFreezeStatusWithSafety() {
 		// given:
-		unusableAtFirst.setAccountKycGrantedByDefault(true);
+		unusableAtFirst.setAccountsKycGrantedByDefault(true);
 		unusableAtFirst.setFreezeKey(MerkleToken.UNUSED_KEY);
 
 		// when:

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleTokenTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleTokenTest.java
@@ -68,7 +68,7 @@ class MerkleTokenTest {
 	long autoRenewPeriod = 1_234_567, otherAutoRenewPeriod = 2_345_678;
 	long tokenFloat = 1_000_000, otherFloat = 1_000_001;
 	boolean freezeDefault = true, otherFreezeDefault = false;
-	boolean kycDefault = true, otherKycDefault = false;
+	boolean accountsKycGrantedByDefault = true, otherAccountsKycGrantedByDefault = false;
 	EntityId treasury = new EntityId(1, 2, 3),
 			otherTreasury = new EntityId(3, 2, 1);
 	EntityId autoRenewAccount = new EntityId(2, 3, 4),
@@ -92,7 +92,7 @@ class MerkleTokenTest {
 		otherSupplyKey = new JEd25519Key("not-a-real-supply-key-either".getBytes());
 
 		subject = new MerkleToken(
-				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, kycDefault, treasury);
+				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, accountsKycGrantedByDefault, treasury);
 		setOptionalElements(subject);
 		subject.setAdminKey(adminKey);
 		subject.setFreezeKey(freezeKey);
@@ -198,7 +198,7 @@ class MerkleTokenTest {
 	public void objectContractHoldsForDifferentFloats() {
 		// given:
 		other = new MerkleToken(
-				expiry, otherFloat, divisibility, symbol, name, freezeDefault, kycDefault, treasury);
+				expiry, otherFloat, divisibility, symbol, name, freezeDefault, accountsKycGrantedByDefault, treasury);
 		setOptionalElements(other);
 
 		// expect:
@@ -211,7 +211,7 @@ class MerkleTokenTest {
 	public void objectContractHoldsForDifferentDivisibility() {
 		// given:
 		other = new MerkleToken(
-				expiry, tokenFloat, otherDivisibility, symbol, name, freezeDefault, kycDefault, treasury);
+				expiry, tokenFloat, otherDivisibility, symbol, name, freezeDefault, accountsKycGrantedByDefault, treasury);
 		setOptionalElements(other);
 
 		// expect:
@@ -224,7 +224,7 @@ class MerkleTokenTest {
 	public void objectContractHoldsForDifferentWipeKey() {
 		// given:
 		other = new MerkleToken(
-				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, kycDefault, treasury);
+				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, accountsKycGrantedByDefault, treasury);
 		setOptionalElements(other);
 		other.setWipeKey(otherWipeKey);
 
@@ -238,7 +238,7 @@ class MerkleTokenTest {
 	public void objectContractHoldsForDifferentSupply() {
 		// given:
 		other = new MerkleToken(
-				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, kycDefault, treasury);
+				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, accountsKycGrantedByDefault, treasury);
 		setOptionalElements(other);
 		other.setSupplyKey(otherSupplyKey);
 
@@ -252,7 +252,7 @@ class MerkleTokenTest {
 	public void objectContractHoldsForDifferentDeleted() {
 		// given:
 		other = new MerkleToken(
-				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, kycDefault, treasury);
+				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, accountsKycGrantedByDefault, treasury);
 		setOptionalElements(other);
 		other.setDeleted(otherIsDeleted);
 
@@ -266,7 +266,7 @@ class MerkleTokenTest {
 	public void objectContractHoldsForDifferentAdminKey() {
 		// given:
 		other = new MerkleToken(
-				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, kycDefault, treasury);
+				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, accountsKycGrantedByDefault, treasury);
 		setOptionalElements(other);
 		other.setAdminKey(otherAdminKey);
 
@@ -280,7 +280,7 @@ class MerkleTokenTest {
 	public void objectContractHoldsForDifferentAutoRenewPeriods() {
 		// given:
 		other = new MerkleToken(
-				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, kycDefault, treasury);
+				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, accountsKycGrantedByDefault, treasury);
 		setOptionalElements(other);
 		other.setAutoRenewPeriod(otherAutoRenewPeriod);
 
@@ -294,7 +294,7 @@ class MerkleTokenTest {
 	public void objectContractHoldsForDifferentAutoRenewAccounts() {
 		// given:
 		other = new MerkleToken(
-				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, kycDefault, treasury);
+				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, accountsKycGrantedByDefault, treasury);
 		setOptionalElements(other);
 		other.setAutoRenewAccount(otherAutoRenewAccount);
 
@@ -308,7 +308,7 @@ class MerkleTokenTest {
 	public void objectContractHoldsForDifferentExpiries() {
 		// given:
 		other = new MerkleToken(
-				otherExpiry, tokenFloat, divisibility, symbol, name, freezeDefault, kycDefault, treasury);
+				otherExpiry, tokenFloat, divisibility, symbol, name, freezeDefault, accountsKycGrantedByDefault, treasury);
 		setOptionalElements(other);
 
 		// expect:
@@ -321,7 +321,7 @@ class MerkleTokenTest {
 	public void objectContractHoldsForDifferentSymbol() {
 		// given:
 		other = new MerkleToken(
-				expiry, tokenFloat, divisibility, otherSymbol, name, freezeDefault, kycDefault, treasury);
+				expiry, tokenFloat, divisibility, otherSymbol, name, freezeDefault, accountsKycGrantedByDefault, treasury);
 		setOptionalElements(other);
 
 		// expect:
@@ -334,7 +334,7 @@ class MerkleTokenTest {
 	public void objectContractHoldsForDifferentName() {
 		// given:
 		other = new MerkleToken(
-				expiry, tokenFloat, divisibility, symbol, otherName, freezeDefault, kycDefault, treasury);
+				expiry, tokenFloat, divisibility, symbol, otherName, freezeDefault, accountsKycGrantedByDefault, treasury);
 		setOptionalElements(other);
 		// expect:
 		assertNotEquals(subject, other);
@@ -346,7 +346,7 @@ class MerkleTokenTest {
 	public void objectContractHoldsForDifferentFreezeDefault() {
 		// given:
 		other = new MerkleToken(
-				expiry, tokenFloat, divisibility, symbol, name, otherFreezeDefault, kycDefault, treasury);
+				expiry, tokenFloat, divisibility, symbol, name, otherFreezeDefault, accountsKycGrantedByDefault, treasury);
 		setOptionalElements(other);
 
 		// expect:
@@ -356,10 +356,10 @@ class MerkleTokenTest {
 	}
 
 	@Test
-	public void objectContractHoldsForDifferentKycDefault() {
+	public void objectContractHoldsForDifferentaccountsKycGrantedByDefault() {
 		// given:
 		other = new MerkleToken(
-				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, otherKycDefault, treasury);
+				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, otherAccountsKycGrantedByDefault, treasury);
 		setOptionalElements(other);
 
 		// expect:
@@ -372,7 +372,7 @@ class MerkleTokenTest {
 	public void objectContractHoldsForDifferentTreasury() {
 		// given:
 		other = new MerkleToken(
-				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, kycDefault, otherTreasury);
+				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, accountsKycGrantedByDefault, otherTreasury);
 		setOptionalElements(other);
 
 		// expect:
@@ -385,7 +385,7 @@ class MerkleTokenTest {
 	public void objectContractHoldsForDifferentKycKeys() {
 		// given:
 		other = new MerkleToken(
-				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, kycDefault, treasury);
+				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, accountsKycGrantedByDefault, treasury);
 		setOptionalElements(other);
 		other.setKycKey(otherKycKey);
 
@@ -407,7 +407,7 @@ class MerkleTokenTest {
 	public void objectContractHoldsForDifferentFreezeKeys() {
 		// given:
 		other = new MerkleToken(
-				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, kycDefault, treasury);
+				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, accountsKycGrantedByDefault, treasury);
 		setOptionalElements(other);
 		other.setFreezeKey(otherFreezeKey);
 
@@ -442,14 +442,14 @@ class MerkleTokenTest {
 		var defaultSubject = new MerkleAccountState();
 		// and:
 		var identicalSubject = new MerkleToken(
-				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, kycDefault, treasury);
+				expiry, tokenFloat, divisibility, symbol, name, freezeDefault, accountsKycGrantedByDefault, treasury);
 		setOptionalElements(identicalSubject);
 		identicalSubject.setDeleted(isDeleted);
 
 		// and:
 		other = new MerkleToken(
 				otherExpiry, otherFloat, otherDivisibility, otherSymbol, otherName,
-				otherFreezeDefault, otherKycDefault, otherTreasury);
+				otherFreezeDefault, otherAccountsKycGrantedByDefault, otherTreasury);
 
 		// expect:
 		assertNotEquals(subject.hashCode(), defaultSubject.hashCode());
@@ -483,7 +483,7 @@ class MerkleTokenTest {
 						"wipeKey=" + describe(wipeKey) + ", " +
 						"supplyKey=" + describe(supplyKey) + ", " +
 						"freezeKey=" + describe(freezeKey) + ", " +
-						"accountsKycGrantedByDefault=" + kycDefault + ", " +
+						"accountsKycGrantedByDefault=" + accountsKycGrantedByDefault + ", " +
 						"accountsFrozenByDefault=" + freezeDefault + "}",
 				subject.toString());
 	}

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleTokenTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleTokenTest.java
@@ -483,7 +483,7 @@ class MerkleTokenTest {
 						"wipeKey=" + describe(wipeKey) + ", " +
 						"supplyKey=" + describe(supplyKey) + ", " +
 						"freezeKey=" + describe(freezeKey) + ", " +
-						"accountKycGrantedByDefault=" + kycDefault + ", " +
+						"accountsKycGrantedByDefault=" + kycDefault + ", " +
 						"accountsFrozenByDefault=" + freezeDefault + "}",
 				subject.toString());
 	}

--- a/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
@@ -1837,6 +1837,21 @@ class HederaTokenStoreTest {
 	}
 
 	@Test
+	public void forcesToTrueKycDefaultWithoutKycKey() {
+		// given:
+		var req = fullyValidAttempt()
+				.clearKycKey()
+				.build();
+
+		// when:
+		var result = subject.createProvisionally(req, sponsor, thisSecond);
+
+		// then:
+		assertEquals(ResponseCodeEnum.OK, result.getStatus());
+		assertTrue(subject.pendingCreation.accountsKycGrantedByDefault());
+	}
+
+	@Test
 	public void rejectsFreezeDefaultWithoutFreezeKey() {
 		// given:
 		var req = fullyValidAttempt()

--- a/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
@@ -114,7 +114,7 @@ class HederaTokenStoreTest {
 	TokenID misc = IdUtils.asToken("3.2.1");
 	TokenRef miscRef = IdUtils.asIdRef(misc);
 	boolean freezeDefault = true;
-	boolean kycDefault = false;
+	boolean accountsKycGrantedByDefault = false;
 	long autoRenewPeriod = 500_000;
 	long newAutoRenewPeriod = 2_000_000;
 	AccountID autoRenewAccount = IdUtils.asAccount("1.2.5");
@@ -1339,9 +1339,9 @@ class HederaTokenStoreTest {
 		given(token.accountsAreFrozenByDefault()).willReturn(freezeDefault);
 	}
 
-	private void givenTokenWithKycKey(boolean kycDefault) {
+	private void givenTokenWithKycKey(boolean accountsKycGrantedByDefault) {
 		given(token.kycKey()).willReturn(Optional.of(CARELESS_SIGNING_PAYER_KT.asJKeyUnchecked()));
-		given(token.accountsKycGrantedByDefault()).willReturn(kycDefault);
+		given(token.accountsKycGrantedByDefault()).willReturn(accountsKycGrantedByDefault);
 	}
 
 	@Test
@@ -1482,7 +1482,7 @@ class HederaTokenStoreTest {
 				symbol,
 				name,
 				freezeDefault,
-				kycDefault,
+				accountsKycGrantedByDefault,
 				new EntityId(treasury.getShardNum(), treasury.getRealmNum(), treasury.getAccountNum()));
 		expected.setAutoRenewAccount(EntityId.ofNullableAccountId(autoRenewAccount));
 		expected.setAutoRenewPeriod(autoRenewPeriod);
@@ -1520,7 +1520,7 @@ class HederaTokenStoreTest {
 				symbol,
 				name,
 				freezeDefault,
-				kycDefault,
+				accountsKycGrantedByDefault,
 				new EntityId(treasury.getShardNum(), treasury.getRealmNum(), treasury.getAccountNum()));
 		expected.setAdminKey(TOKEN_ADMIN_KT.asJKeyUnchecked());
 		expected.setFreezeKey(TOKEN_FREEZE_KT.asJKeyUnchecked());
@@ -1837,7 +1837,7 @@ class HederaTokenStoreTest {
 	}
 
 	@Test
-	public void forcesToTrueKycDefaultWithoutKycKey() {
+	public void forcesToTrueAccountsKycGrantedByDefaultWithoutKycKey() {
 		// given:
 		var req = fullyValidAttempt()
 				.clearKycKey()

--- a/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
@@ -114,7 +114,7 @@ class HederaTokenStoreTest {
 	TokenID misc = IdUtils.asToken("3.2.1");
 	TokenRef miscRef = IdUtils.asIdRef(misc);
 	boolean freezeDefault = true;
-	boolean kycDefault = true;
+	boolean kycDefault = false;
 	long autoRenewPeriod = 500_000;
 	long newAutoRenewPeriod = 2_000_000;
 	AccountID autoRenewAccount = IdUtils.asAccount("1.2.5");
@@ -1850,22 +1850,6 @@ class HederaTokenStoreTest {
 		assertEquals(ResponseCodeEnum.TOKEN_HAS_NO_FREEZE_KEY, result.getStatus());
 	}
 
-	@Test
-	public void forcesToTrueKycDefaultWithoutKycKey() {
-		// given:
-		var req = fullyValidAttempt()
-				.clearKycKey()
-				.setKycDefault(false)
-				.build();
-
-		// when:
-		var result = subject.createProvisionally(req, sponsor, thisSecond);
-
-		// then:
-		assertEquals(ResponseCodeEnum.OK, result.getStatus());
-		assertTrue(subject.pendingCreation.accountKycGrantedByDefault());
-	}
-
 	TokenCreateTransactionBody.Builder fullyValidAttempt() {
 		return TokenCreateTransactionBody.newBuilder()
 				.setExpiry(expiry)
@@ -1879,7 +1863,6 @@ class HederaTokenStoreTest {
 				.setInitialSupply(tokenFloat)
 				.setTreasury(treasury)
 				.setDecimals(divisibility)
-				.setFreezeDefault(freezeDefault)
-				.setKycDefault(kycDefault);
+				.setFreezeDefault(freezeDefault);
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
@@ -1341,7 +1341,7 @@ class HederaTokenStoreTest {
 
 	private void givenTokenWithKycKey(boolean kycDefault) {
 		given(token.kycKey()).willReturn(Optional.of(CARELESS_SIGNING_PAYER_KT.asJKeyUnchecked()));
-		given(token.accountKycGrantedByDefault()).willReturn(kycDefault);
+		given(token.accountsKycGrantedByDefault()).willReturn(kycDefault);
 	}
 
 	@Test

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCreate.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCreate.java
@@ -66,7 +66,6 @@ public class HapiTokenCreate extends HapiTxnOp<HapiTokenCreate> {
 	private Optional<String> treasury = Optional.empty();
 	private Optional<String> adminKey = Optional.empty();
 	private Optional<Boolean> freezeDefault = Optional.empty();
-	private Optional<Boolean> kycDefault = Optional.empty();
 	private Optional<String> autoRenewAccount = Optional.empty();
 	private Optional<Function<HapiApiSpec, String>> symbolFn = Optional.empty();
 	private Optional<Function<HapiApiSpec, String>> nameFn = Optional.empty();
@@ -87,11 +86,6 @@ public class HapiTokenCreate extends HapiTxnOp<HapiTokenCreate> {
 
 	public HapiTokenCreate divisibility(int divisibility) {
 		this.divisibility = OptionalInt.of(divisibility);
-		return this;
-	}
-
-	public HapiTokenCreate kycDefault(boolean knownByDefault) {
-		kycDefault = Optional.of(knownByDefault);
 		return this;
 	}
 
@@ -210,7 +204,6 @@ public class HapiTokenCreate extends HapiTxnOp<HapiTokenCreate> {
 							initialFloat.ifPresent(b::setInitialSupply);
 							divisibility.ifPresent(b::setDecimals);
 							freezeDefault.ifPresent(b::setFreezeDefault);
-							kycDefault.ifPresent(b::setKycDefault);
 							adminKey.ifPresent(k -> b.setAdminKey(spec.registry().getKey(k)));
 							freezeKey.ifPresent(k -> b.setFreezeKey(spec.registry().getKey(k)));
 							supplyKey.ifPresent(k -> b.setSupplyKey(spec.registry().getKey(k)));

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenDeleteSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenDeleteSpecs.java
@@ -74,7 +74,6 @@ public class TokenDeleteSpecs extends HapiApiSuite {
 								.balance(A_HUNDRED_HBARS),
 						tokenCreate("tbd")
 								.freezeDefault(false)
-								.kycDefault(true)
 								.treasury(TOKEN_TREASURY)
 								.payingWith("payer")
 				).when( ).then(
@@ -99,7 +98,6 @@ public class TokenDeleteSpecs extends HapiApiSuite {
 								.wipeKey("multiKey")
 								.supplyKey("multiKey")
 								.freezeDefault(false)
-								.kycDefault(true)
 								.treasury(TOKEN_TREASURY)
 								.payingWith("payer")
 				).when(

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -143,39 +143,38 @@ public class TokenManagementSpecs extends HapiApiSuite {
 	}
 
 	public HapiApiSpec kycMgmtFailureCasesWork() {
-		var unknowableToken = "without";
-		var knowableToken = "withPlusDefaultTrue";
+		var withoutKycKey = "withoutKycKey";
+		var withKycKey = "withKycKey";
 
 		return defaultHapiSpec("KycMgmtFailureCasesWork")
 				.given(
 						newKeyNamed("oneKyc"),
 						cryptoCreate(TOKEN_TREASURY),
-						tokenCreate(unknowableToken)
-								.name(salted("name"))
+						tokenCreate(withoutKycKey)
 								.treasury(TOKEN_TREASURY),
-						tokenCreate(knowableToken)
+						tokenCreate(withKycKey)
 								.kycKey("oneKyc")
 								.treasury(TOKEN_TREASURY)
 				).when(
-						grantTokenKyc(unknowableToken, TOKEN_TREASURY)
+						grantTokenKyc(withoutKycKey, TOKEN_TREASURY)
 								.signedBy(GENESIS)
 								.hasKnownStatus(TOKEN_HAS_NO_KYC_KEY),
-						grantTokenKyc(knowableToken, "1.2.3")
+						grantTokenKyc(withKycKey, "1.2.3")
 								.hasKnownStatus(INVALID_ACCOUNT_ID),
-						grantTokenKyc(knowableToken, TOKEN_TREASURY)
+						grantTokenKyc(withKycKey, TOKEN_TREASURY)
 								.signedBy(GENESIS)
 								.hasKnownStatus(INVALID_SIGNATURE),
-						grantTokenKyc(unknowableToken, TOKEN_TREASURY)
+						grantTokenKyc(withoutKycKey, TOKEN_TREASURY)
 								.signedBy(GENESIS)
 								.hasKnownStatus(TOKEN_HAS_NO_KYC_KEY),
-						revokeTokenKyc(knowableToken, "1.2.3")
+						revokeTokenKyc(withKycKey, "1.2.3")
 								.hasKnownStatus(INVALID_ACCOUNT_ID),
-						revokeTokenKyc(knowableToken, TOKEN_TREASURY)
+						revokeTokenKyc(withKycKey, TOKEN_TREASURY)
 								.signedBy(GENESIS)
 								.hasKnownStatus(INVALID_SIGNATURE)
 				).then(
-						getTokenInfo(unknowableToken)
-								.hasRegisteredId(unknowableToken)
+						getTokenInfo(withoutKycKey)
+								.hasRegisteredId(withoutKycKey)
 								.logged()
 				);
 	}
@@ -256,8 +255,8 @@ public class TokenManagementSpecs extends HapiApiSuite {
 	}
 
 	public HapiApiSpec kycMgmtSuccessCasesWork() {
-		var withPlusDefaultTrue = "withPlusDefaultTrue";
-		var withPlusDefaultFalse = "withPlusDefaultFalse";
+		var withKycKey = "withKycKey";
+		var withoutKycKey = "withoutKycKey";
 
 		return defaultHapiSpec("KycMgmtSuccessCasesWork")
 				.given(
@@ -265,23 +264,28 @@ public class TokenManagementSpecs extends HapiApiSuite {
 						cryptoCreate("misc"),
 						newKeyNamed("oneKyc"),
 						newKeyNamed("twoKyc"),
-						tokenCreate(withPlusDefaultTrue)
+						tokenCreate(withKycKey)
 								.kycKey("oneKyc")
 								.treasury(TOKEN_TREASURY),
-						tokenCreate(withPlusDefaultFalse)
+						tokenCreate(withoutKycKey)
 								.treasury(TOKEN_TREASURY)
 				).when(
 						tokenTransact(
-								moving(1, withPlusDefaultTrue)
+								moving(1, withKycKey)
 										.between(TOKEN_TREASURY, "misc"))
 								.hasKnownStatus(ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN),
 						getAccountInfo("misc").logged(),
-						grantTokenKyc(withPlusDefaultTrue, "misc"),
+						grantTokenKyc(withKycKey, "misc"),
 						tokenTransact(
-								moving(1, withPlusDefaultTrue)
+								moving(1, withKycKey)
 										.between(TOKEN_TREASURY, "misc")),
+						revokeTokenKyc(withKycKey, "misc"),
 						tokenTransact(
-								moving(1, withPlusDefaultFalse)
+								moving(1, withKycKey)
+										.between(TOKEN_TREASURY, "misc"))
+								.hasKnownStatus(ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN),
+						tokenTransact(
+								moving(1, withoutKycKey)
 										.between(TOKEN_TREASURY, "misc"))
 				).then(
 						getAccountInfo("misc").logged()

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -154,7 +154,6 @@ public class TokenManagementSpecs extends HapiApiSuite {
 								.name(salted("name"))
 								.treasury(TOKEN_TREASURY),
 						tokenCreate(knowableToken)
-								.kycDefault(false)
 								.kycKey("oneKyc")
 								.treasury(TOKEN_TREASURY)
 				).when(
@@ -267,24 +266,20 @@ public class TokenManagementSpecs extends HapiApiSuite {
 						newKeyNamed("oneKyc"),
 						newKeyNamed("twoKyc"),
 						tokenCreate(withPlusDefaultTrue)
-								.kycDefault(true)
 								.kycKey("oneKyc")
 								.treasury(TOKEN_TREASURY),
 						tokenCreate(withPlusDefaultFalse)
-								.kycDefault(false)
-								.kycKey("twoKyc")
 								.treasury(TOKEN_TREASURY)
 				).when(
-						tokenTransact(
-								moving(1, withPlusDefaultTrue)
-										.between(TOKEN_TREASURY, "misc")),
-						revokeTokenKyc(withPlusDefaultTrue, "misc"),
 						tokenTransact(
 								moving(1, withPlusDefaultTrue)
 										.between(TOKEN_TREASURY, "misc"))
 								.hasKnownStatus(ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN),
 						getAccountInfo("misc").logged(),
-						grantTokenKyc(withPlusDefaultFalse, "misc"),
+						grantTokenKyc(withPlusDefaultTrue, "misc"),
+						tokenTransact(
+								moving(1, withPlusDefaultTrue)
+										.between(TOKEN_TREASURY, "misc")),
 						tokenTransact(
 								moving(1, withPlusDefaultFalse)
 										.between(TOKEN_TREASURY, "misc"))

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
@@ -104,7 +104,6 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 								.balance(A_HUNDRED_HBARS),
 						tokenCreate("tbd")
 								.freezeDefault(false)
-								.kycDefault(true)
 								.treasury(TOKEN_TREASURY)
 				).when().then(
 						tokenUpdate("tbd")
@@ -128,7 +127,6 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 						cryptoCreate(TOKEN_TREASURY),
 						tokenCreate("tbu")
 								.treasury(TOKEN_TREASURY)
-								.kycDefault(false)
 								.freezeDefault(true)
 								.initialFloat(10)
 								.adminKey("adminKey")
@@ -173,7 +171,6 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 						cryptoCreate("newTreasury"),
 						tokenCreate("tbu")
 								.adminKey("adminKey")
-								.kycDefault(false)
 								.freezeDefault(true)
 								.kycKey("kycKey")
 								.freezeKey("freezeKey")


### PR DESCRIPTION
**Related issue(s)**:
Closes #None

**Summary of the change**:
Granted KYC is now based on whether upon token creation a kyc key has been provided.
If provided -> kyc is not granted by default.
If not -> kyc is granted by default.

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [x] HAPI protobuf comments
- [ ] README
