### PR TITLE
Fix(token): burn must not decrement total supply if adjustments fail

### DIFF
--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -389,10 +389,15 @@ public class TokenManagementSpecs extends HapiApiSuite {
 									.hasKnownStatus(TOKEN_HAS_NO_SUPPLY_KEY),
 							mintToken("supple", Long.MAX_VALUE)
 									.hasKnownStatus(INVALID_TOKEN_MINT_AMOUNT),
+							mintToken("supply", 0)
+									.hasKnownStatus(INVALID_TOKEN_MINT_AMOUNT),
 							burnToken("supple", 2)
+									.hasKnownStatus(INVALID_TOKEN_BURN_AMOUNT),
+							burnToken("supply", 0)
 									.hasKnownStatus(INVALID_TOKEN_BURN_AMOUNT)
 					),
-				burnTokenFailsDueToInsufficientTreasuryBalance());
+				burnTokenFailsDueToInsufficientTreasuryBalance()
+		);
 	}
 
 	@Override


### PR DESCRIPTION
**Related issue(s)**:
Closes https://github.com/hashgraph/hedera-services/issues/597

**Summary of the change**:
* Update `changeSupply` functionality.
* Adjust `totalSupply` after validations and adjustments to `treasury`.
* Add tests

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
