### PR TITLE
Feat/add treasury check before deletion prep

### DIFF
--- a/hapi-proto/HAPI.html
+++ b/hapi-proto/HAPI.html
@@ -654,6 +654,10 @@
                   <a href="#proto.TokenBalance"><span class="badge">M</span>TokenBalance</a>
                 </li>
               
+                <li>
+                  <a href="#proto.TokenBalances"><span class="badge">M</span>TokenBalances</a>
+                </li>
+              
               
               
               
@@ -1207,6 +1211,21 @@
         
           
           <li>
+            <a href="#TokenAssociate.proto">TokenAssociate.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#proto.TokenAssociateTransactionBody"><span class="badge">M</span>TokenAssociateTransactionBody</a>
+                </li>
+              
+              
+              
+              
+            </ul>
+          </li>
+        
+          
+          <li>
             <a href="#TokenBurn.proto">TokenBurn.proto</a>
             <ul>
               
@@ -1242,6 +1261,21 @@
               
                 <li>
                   <a href="#proto.TokenDeleteTransactionBody"><span class="badge">M</span>TokenDeleteTransactionBody</a>
+                </li>
+              
+              
+              
+              
+            </ul>
+          </li>
+        
+          
+          <li>
+            <a href="#TokenDissociate.proto">TokenDissociate.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#proto.TokenDissociateTransactionBody"><span class="badge">M</span>TokenDissociateTransactionBody</a>
                 </li>
               
               
@@ -2990,6 +3024,18 @@
                 <td>TokenAccountWipe</td>
                 <td>67</td>
                 <td><p>Wipe token amount from Account holder</p></td>
+              </tr>
+            
+              <tr>
+                <td>TokenAssociateToAccount</td>
+                <td>68</td>
+                <td><p>Associate tokens to an account</p></td>
+              </tr>
+            
+              <tr>
+                <td>TokenDissociateFromAccount</td>
+                <td>69</td>
+                <td><p>Dissociate tokens from an account</p></td>
               </tr>
             
           </tbody>
@@ -4855,6 +4901,30 @@ If unspecified, no change. </p></td>
                   <td><a href="#uint64">uint64</a></td>
                   <td></td>
                   <td><p>The current token balance </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="proto.TokenBalances">TokenBalances</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>tokenBalances</td>
+                  <td><a href="#proto.TokenBalance">TokenBalance</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
                 </tr>
               
             </tbody>
@@ -8156,7 +8226,7 @@ by HAPI.</p></td>
               </tr>
             
               <tr>
-                <td>ACCOUNT_HAS_NO_TOKEN_RELATIONSHIP</td>
+                <td>TOKEN_NOT_ASSOCIATED_TO_ACCOUNT</td>
                 <td>186</td>
                 <td><p></p></td>
               </tr>
@@ -8216,9 +8286,27 @@ by HAPI.</p></td>
               </tr>
             
               <tr>
-                <td>TOKEN_IS_IMMUTABlE</td>
+                <td>TOKEN_IS_IMMUTABLE</td>
                 <td>196</td>
                 <td><p>Token does not have Admin key set, thus update/delete transactions cannot be performed</p></td>
+              </tr>
+            
+              <tr>
+                <td>TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT</td>
+                <td>197</td>
+                <td><p>An &lt;tt&gt;associateToken&lt;/tt&gt; operation specified a token already associated to the account</p></td>
+              </tr>
+            
+              <tr>
+                <td>TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES</td>
+                <td>198</td>
+                <td><p>An attempted operation is invalid until all token balances for the target account are zero</p></td>
+              </tr>
+            
+              <tr>
+                <td>ACCOUNT_IS_TREASURY</td>
+                <td>199</td>
+                <td><p>A selected account is a treasury</p></td>
               </tr>
             
           </tbody>
@@ -8559,6 +8647,51 @@ by HAPI.</p></td>
     
       
       <div class="file-heading">
+        <h2 id="TokenAssociate.proto">TokenAssociate.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="proto.TokenAssociateTransactionBody">TokenAssociateTransactionBody</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>account</td>
+                  <td><a href="#proto.AccountID">AccountID</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tokens</td>
+                  <td><a href="#proto.TokenRef">TokenRef</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+
+      
+
+      
+    
+      
+      <div class="file-heading">
         <h2 id="TokenBurn.proto">TokenBurn.proto</h2><a href="#title">Top</a>
       </div>
       <p></p>
@@ -8753,6 +8886,51 @@ by HAPI.</p></td>
                   <td><a href="#proto.TokenRef">TokenRef</a></td>
                   <td></td>
                   <td><p>The token to be deleted. If invalid token is specified, transaction will result in INVALID_TOKEN_REF </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+
+      
+
+      
+    
+      
+      <div class="file-heading">
+        <h2 id="TokenDissociate.proto">TokenDissociate.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="proto.TokenDissociateTransactionBody">TokenDissociateTransactionBody</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>account</td>
+                  <td><a href="#proto.AccountID">AccountID</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tokens</td>
+                  <td><a href="#proto.TokenRef">TokenRef</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
                 </tr>
               
             </tbody>
@@ -9257,6 +9435,20 @@ by HAPI.</p></td>
                 <td><a href="#proto.Transaction">Transaction</a></td>
                 <td><a href="#proto.TransactionResponse">TransactionResponse</a></td>
                 <td><p>Initiates a Token transfer by submitting the transaction</p></td>
+              </tr>
+            
+              <tr>
+                <td>associateTokens</td>
+                <td><a href="#proto.Transaction">Transaction</a></td>
+                <td><a href="#proto.TransactionResponse">TransactionResponse</a></td>
+                <td><p>Associates tokens to an account</p></td>
+              </tr>
+            
+              <tr>
+                <td>dissociateTokens</td>
+                <td><a href="#proto.Transaction">Transaction</a></td>
+                <td><a href="#proto.TransactionResponse">TransactionResponse</a></td>
+                <td><p>Dissociates tokens from an account</p></td>
               </tr>
             
               <tr>
@@ -9925,6 +10117,20 @@ by HAPI.</p></td>
                   <td><a href="#proto.TokenWipeAccountTransactionBody">TokenWipeAccountTransactionBody</a></td>
                   <td></td>
                   <td><p>Wipes amount of tokens from an account </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tokenAssociate</td>
+                  <td><a href="#proto.TokenAssociateTransactionBody">TokenAssociateTransactionBody</a></td>
+                  <td></td>
+                  <td><p>Associate tokens to an account </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tokenDissociate</td>
+                  <td><a href="#proto.TokenDissociateTransactionBody">TokenDissociateTransactionBody</a></td>
+                  <td></td>
+                  <td><p>Dissociate tokens from an account </p></td>
                 </tr>
               
             </tbody>

--- a/hapi-proto/src/main/proto/ResponseCode.proto
+++ b/hapi-proto/src/main/proto/ResponseCode.proto
@@ -210,5 +210,5 @@ enum ResponseCodeEnum {
   TOKEN_IS_IMMUTABLE = 196; // Token does not have Admin key set, thus update/delete transactions cannot be performed
   TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT = 197; // An <tt>associateToken</tt> operation specified a token already associated to the account
   TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES = 198; // An attempted operation is invalid until all token balances for the target account are zero
-  ACCOUNT_IS_TREASURY = 199;  // A selected account is a treasury
+  ACCOUNT_IS_TREASURY = 199;  // An attempted operation is invalid because the account is a treasury
 }

--- a/hapi-proto/src/main/proto/ResponseCode.proto
+++ b/hapi-proto/src/main/proto/ResponseCode.proto
@@ -210,5 +210,5 @@ enum ResponseCodeEnum {
   TOKEN_IS_IMMUTABLE = 196; // Token does not have Admin key set, thus update/delete transactions cannot be performed
   TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT = 197; // An <tt>associateToken</tt> operation specified a token already associated to the account
   TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES = 198; // An attempted operation is invalid until all token balances for the target account are zero
-  ACCOUNT_IS_TREASURY = 199;
+  ACCOUNT_IS_TREASURY = 199;  // A selected account is a treasury
 }

--- a/hapi-proto/src/main/proto/ResponseCode.proto
+++ b/hapi-proto/src/main/proto/ResponseCode.proto
@@ -207,7 +207,8 @@ enum ResponseCodeEnum {
   MISSING_TOKEN_NAME = 193; // Token Name is not provided
   TOKEN_NAME_TOO_LONG = 194; // Token name is too long
   INVALID_WIPING_AMOUNT = 195; // The provided wipe amount must not be negative, zero or bigger than the token holder balance
-  TOKEN_IS_IMMUTABlE = 196; // Token does not have Admin key set, thus update/delete transactions cannot be performed
+  TOKEN_IS_IMMUTABLE = 196; // Token does not have Admin key set, thus update/delete transactions cannot be performed
   TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT = 197; // An <tt>associateToken</tt> operation specified a token already associated to the account
   TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES = 198; // An attempted operation is invalid until all token balances for the target account are zero
+  ACCOUNT_IS_TREASURY = 199;
 }

--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -932,7 +932,7 @@ public class ServicesContext {
 				entry(CryptoUpdate,
 						List.of(new CryptoUpdateTransitionLogic(ledger(), validator(), txnCtx()))),
 				entry(CryptoDelete,
-						List.of(new CryptoDeleteTransitionLogic(ledger(), txnCtx()))),
+						List.of(new CryptoDeleteTransitionLogic(ledger(), tokenStore(), txnCtx()))),
 				entry(CryptoTransfer,
 						List.of(new CryptoTransferTransitionLogic(ledger(), validator(), txnCtx()))),
 				/* File */

--- a/hedera-node/src/main/java/com/hedera/services/tokens/ExceptionalTokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/tokens/ExceptionalTokenStore.java
@@ -72,6 +72,11 @@ public enum ExceptionalTokenStore implements TokenStore {
 	}
 
 	@Override
+	public boolean isKnownTreasury(AccountID aId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public ResponseCodeEnum update(TokenUpdateTransactionBody changes, long now) {
 		throw new UnsupportedOperationException();
 	}

--- a/hedera-node/src/main/java/com/hedera/services/tokens/TokenStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/tokens/TokenStore.java
@@ -56,6 +56,7 @@ public interface TokenStore {
 	boolean exists(TokenID id);
 	boolean symbolExists(String symbol);
 	boolean nameExists(String name);
+	boolean isKnownTreasury(AccountID id);
 	TokenID lookup(String symbol);
 	MerkleToken get(TokenID id);
 
@@ -94,7 +95,7 @@ public interface TokenStore {
 
 		var token = get(id);
 		if (token.adminKey().isEmpty()) {
-			return TOKEN_IS_IMMUTABlE;
+			return TOKEN_IS_IMMUTABLE;
 		}
 		if (token.isDeleted()) {
 			return TOKEN_WAS_DELETED;

--- a/hedera-node/src/main/java/com/hedera/services/txns/token/TokenUpdateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/token/TokenUpdateTransitionLogic.java
@@ -28,13 +28,11 @@ import com.hedera.services.txns.TransitionLogic;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenID;
-import com.hederahashgraph.api.proto.java.TokenRef;
 import com.hederahashgraph.api.proto.java.TokenUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -87,7 +85,7 @@ public class TokenUpdateTransitionLogic implements TransitionLogic {
 		MerkleToken token = store.get(id);
 
 		if (token.adminKey().isEmpty() && !affectsExpiryOnly.test(op)) {
-			txnCtx.setStatus(TOKEN_IS_IMMUTABlE);
+			txnCtx.setStatus(TOKEN_IS_IMMUTABLE);
 			return;
 		}
 

--- a/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/tokens/HederaTokenStoreTest.java
@@ -50,6 +50,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -429,41 +430,46 @@ class HederaTokenStoreTest {
 
 	@Test
 	public void treasuryRemovalForTokenRemovesKeyWhenEmpty() {
-		subject.addKnownTreasury(treasury, misc);
+		Set<TokenID> tokenSet = new HashSet<>(Arrays.asList(misc));
+		subject.knownTreasuries.put(treasury, tokenSet);
 
 		subject.removeKnownTreasuryForToken(treasury, misc);
 
 		// expect:
-		assertFalse(subject.isKnownTreasury(treasury));
+		assertFalse(subject.knownTreasuries.containsKey(treasury));
 		assertTrue(subject.knownTreasuries.isEmpty());
 	}
 
 	@Test
 	public void addKnownTreasuryWorks() {
-		subject.addKnownTreasury(treasury, misc);
+		Set<TokenID> tokenSet = new HashSet<>(Arrays.asList(misc));
+		subject.knownTreasuries.put(treasury, tokenSet);
 
 		// expect:
-		assertTrue(subject.isKnownTreasury(treasury));
+		assertTrue(subject.knownTreasuries.containsKey(treasury));
 	}
 
 	@Test
 	public void removeKnownTreasuryWorks() {
-		subject.addKnownTreasury(treasury, misc);
-		subject.addKnownTreasury(treasury, anotherMisc);
+		Set<TokenID> tokenSet = new HashSet<>(Arrays.asList(misc, anotherMisc));
+		subject.knownTreasuries.put(treasury, tokenSet);
 
 		subject.removeKnownTreasuryForToken(treasury, misc);
 
 		// expect:
-		assertTrue(subject.isKnownTreasury(treasury));
+		assertTrue(subject.knownTreasuries.containsKey(treasury));
 		assertEquals(1, subject.knownTreasuries.size());
+		assertTrue(subject.knownTreasuries.get(treasury).contains(anotherMisc));
 	}
 
 	@Test
 	public void isKnownTreasuryWorks() {
-		given(subject.knownTreasuries.containsKey(treasury)).willReturn(true);
+		Set<TokenID> tokenSet = new HashSet<>(Arrays.asList(misc));
+
+		subject.knownTreasuries.put(treasury, tokenSet);
 
 		// expect:
-		assertTrue(subject.isKnownTreasury(treasury));
+		assertTrue(subject.knownTreasuries.containsKey(treasury));
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/txns/token/TokenUpdateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/token/TokenUpdateTransitionLogicTest.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_REF;
@@ -52,13 +51,11 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TREASURY_ACCOUNT_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_IS_IMMUTABlE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_IS_IMMUTABLE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_WAS_DELETED;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.anyLong;
@@ -250,7 +247,7 @@ class TokenUpdateTransitionLogicTest {
 		subject.doStateTransition();
 
 		// then:
-		verify(txnCtx).setStatus(TOKEN_IS_IMMUTABlE);
+		verify(txnCtx).setStatus(TOKEN_IS_IMMUTABLE);
 	}
 
 	@Test

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteSuite.java
@@ -82,7 +82,7 @@ public class CryptoDeleteSuite extends HapiApiSuite {
 						cryptoCreate("transferAccount").balance(0L)
 				).when(
 						cryptoDelete("toBeDeleted")
-								.transfer("transferAccount").via("deleteTxn")
+								.transfer("transferAccount")
 				).then(
 						getAccountInfo("transferAccount")
 								.has(accountWith().balance(B)),
@@ -130,7 +130,6 @@ public class CryptoDeleteSuite extends HapiApiSuite {
 				.then(
 						cryptoDelete("toBeDeleted")
 								.transfer("transferAccount")
-								.via("deleteTxn")
 								.hasKnownStatus(ACCOUNT_DELETED)
 				);
 	}
@@ -171,7 +170,6 @@ public class CryptoDeleteSuite extends HapiApiSuite {
 				.then(
 						cryptoDelete("treasury")
 								.transfer("transferAccount")
-								.via("deleteTxn")
 								.hasKnownStatus(ACCOUNT_IS_TREASURY)
 						);
 	}

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteSuite.java
@@ -83,6 +83,7 @@ public class CryptoDeleteSuite extends HapiApiSuite {
 				).when(
 						cryptoDelete("toBeDeleted")
 								.transfer("transferAccount")
+								.via("deleteTxn")
 				).then(
 						getAccountInfo("transferAccount")
 								.has(accountWith().balance(B)),
@@ -120,9 +121,6 @@ public class CryptoDeleteSuite extends HapiApiSuite {
 						cryptoCreate("transferAccount")
 				)
 				.when(
-						tokenCreate("toBeTransferred")
-								.initialSupply(TOKEN_INITIAL_SUPPLY)
-								.treasury("treasury"),
 						cryptoDelete("toBeDeleted")
 								.transfer("transferAccount")
 								.hasKnownStatus(SUCCESS)
@@ -141,11 +139,7 @@ public class CryptoDeleteSuite extends HapiApiSuite {
 						cryptoCreate("toBeDeleted"),
 						cryptoCreate("transferAccount")
 				)
-				.when(
-						tokenCreate("toBeTransferred")
-								.initialSupply(TOKEN_INITIAL_SUPPLY)
-								.treasury("treasury")
-				)
+				.when()
 				.then(
 						cryptoDelete("toBeDeleted")
 								.transfer("toBeDeleted")
@@ -157,12 +151,9 @@ public class CryptoDeleteSuite extends HapiApiSuite {
 		return defaultHapiSpec("CannotDeleteTreasuryAccount")
 				.given(
 						cryptoCreate("treasury"),
-						cryptoCreate("toBeDeleted"),
-						cryptoCreate("nonexistingAccount"),
-						cryptoCreate("transferAccount").balance(0L)
+						cryptoCreate("transferAccount")
 				)
 				.when(
-						cryptoDelete("nonexistingAccount"),
 						tokenCreate("toBeTransferred")
 								.initialSupply(TOKEN_INITIAL_SUPPLY)
 								.treasury("treasury")

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteSuite.java
@@ -66,10 +66,9 @@ public class CryptoDeleteSuite extends HapiApiSuite {
 		return List.of(new HapiApiSpec[] {
 				fundsTransferOnDelete(),
 				cannotDeleteAccountsWithNonzeroTokenBalances(),
-				deletionOfAlreadyDeletedAccount(),
-				sameAccountAndBeneficiaryFailure(),
-				deletionAttemptOfTreasuryFailure(),
-				nonExistingAccountDeletionAttempt()
+				cannotDeleteAlreadyDeletedAccount(),
+				cannotDeleteAccountWithSameBeneficiary(),
+				cannotDeleteTreasuryAccount(),
 		});
 	}
 
@@ -113,22 +112,19 @@ public class CryptoDeleteSuite extends HapiApiSuite {
 				);
 	}
 
-	private HapiApiSpec deletionOfAlreadyDeletedAccount() {
-		return defaultHapiSpec("DeletionOfAlreadyDeletedAccount")
+	private HapiApiSpec cannotDeleteAlreadyDeletedAccount() {
+		return defaultHapiSpec("CannotDeleteAlreadyDeletedAccount")
 				.given(
 						cryptoCreate("treasury"),
 						cryptoCreate("toBeDeleted"),
-						cryptoCreate("nonexistingAccount"),
-						cryptoCreate("transferAccount").balance(0L)
+						cryptoCreate("transferAccount")
 				)
 				.when(
-						cryptoDelete("nonexistingAccount"),
 						tokenCreate("toBeTransferred")
 								.initialSupply(TOKEN_INITIAL_SUPPLY)
 								.treasury("treasury"),
 						cryptoDelete("toBeDeleted")
 								.transfer("transferAccount")
-								.via("deleteTxn")
 								.hasKnownStatus(SUCCESS)
 				)
 				.then(
@@ -139,16 +135,14 @@ public class CryptoDeleteSuite extends HapiApiSuite {
 				);
 	}
 
-	private HapiApiSpec sameAccountAndBeneficiaryFailure() {
-		return defaultHapiSpec("SameAccountAndBeneficiaryFailure")
+	private HapiApiSpec cannotDeleteAccountWithSameBeneficiary() {
+		return defaultHapiSpec("CannotDeleteAccountWithSameBeneficiary")
 				.given(
 						cryptoCreate("treasury"),
 						cryptoCreate("toBeDeleted"),
-						cryptoCreate("nonexistingAccount"),
-						cryptoCreate("transferAccount").balance(0L)
+						cryptoCreate("transferAccount")
 				)
 				.when(
-						cryptoDelete("nonexistingAccount"),
 						tokenCreate("toBeTransferred")
 								.initialSupply(TOKEN_INITIAL_SUPPLY)
 								.treasury("treasury")
@@ -156,13 +150,12 @@ public class CryptoDeleteSuite extends HapiApiSuite {
 				.then(
 						cryptoDelete("toBeDeleted")
 								.transfer("toBeDeleted")
-								.via("deleteTxn")
 								.hasPrecheck(TRANSFER_ACCOUNT_SAME_AS_DELETE_ACCOUNT)
 						);
 	}
 
-	private HapiApiSpec deletionAttemptOfTreasuryFailure() {
-		return defaultHapiSpec("DeletionAttemptOfTreasuryFailure")
+	private HapiApiSpec cannotDeleteTreasuryAccount() {
+		return defaultHapiSpec("CannotDeleteTreasuryAccount")
 				.given(
 						cryptoCreate("treasury"),
 						cryptoCreate("toBeDeleted"),
@@ -181,28 +174,5 @@ public class CryptoDeleteSuite extends HapiApiSuite {
 								.via("deleteTxn")
 								.hasKnownStatus(ACCOUNT_IS_TREASURY)
 						);
-	}
-
-
-	private HapiApiSpec nonExistingAccountDeletionAttempt() {
-		return defaultHapiSpec("NonExistingAccountDeletionAttempt")
-				.given(
-						cryptoCreate("treasury"),
-						cryptoCreate("toBeDeleted"),
-						cryptoCreate("nonexistingAccount"),
-						cryptoCreate("transferAccount").balance(0L)
-				)
-				.when(
-						cryptoDelete("nonexistingAccount"),
-						tokenCreate("toBeTransferred")
-								.initialSupply(TOKEN_INITIAL_SUPPLY)
-								.treasury("treasury")
-				)
-				.then(
-						cryptoDelete("toBeDeleted")
-								.transfer("nonexistingAccount")
-								.via("deleteTxn")
-								.hasKnownStatus(ACCOUNT_DELETED)
-				);
 	}
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteSuite.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteSuite.java
@@ -116,7 +116,6 @@ public class CryptoDeleteSuite extends HapiApiSuite {
 	private HapiApiSpec cannotDeleteAlreadyDeletedAccount() {
 		return defaultHapiSpec("CannotDeleteAlreadyDeletedAccount")
 				.given(
-						cryptoCreate("treasury"),
 						cryptoCreate("toBeDeleted"),
 						cryptoCreate("transferAccount")
 				)
@@ -135,9 +134,7 @@ public class CryptoDeleteSuite extends HapiApiSuite {
 	private HapiApiSpec cannotDeleteAccountWithSameBeneficiary() {
 		return defaultHapiSpec("CannotDeleteAccountWithSameBeneficiary")
 				.given(
-						cryptoCreate("treasury"),
-						cryptoCreate("toBeDeleted"),
-						cryptoCreate("transferAccount")
+						cryptoCreate("toBeDeleted")
 				)
 				.when()
 				.then(

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenDeleteSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenDeleteSpecs.java
@@ -98,7 +98,7 @@ public class TokenDeleteSpecs extends HapiApiSuite {
 						tokenDelete("tbd")
 								.payingWith("payer")
 								.signedBy("payer")
-								.hasKnownStatus(TOKEN_IS_IMMUTABlE)
+								.hasKnownStatus(TOKEN_IS_IMMUTABLE)
 				);
 	}
 

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
@@ -39,8 +39,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_REF;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_IS_IMMUTABlE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_IS_IMMUTABLE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NAME_TOO_LONG;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_WAS_DELETED;
 
@@ -94,7 +93,7 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 				).when(
 						tokenUpdate("immutable")
 								.treasury(ADDRESS_BOOK_CONTROL)
-								.hasKnownStatus(TOKEN_IS_IMMUTABlE),
+								.hasKnownStatus(TOKEN_IS_IMMUTABLE),
 						tokenUpdate("immutable")
 								.expiry(then - 1)
 								.hasKnownStatus(INVALID_EXPIRATION_TIME),
@@ -131,7 +130,7 @@ public class TokenUpdateSpecs extends HapiApiSuite {
 								.autoRenewAccount(GENESIS)
 								.payingWith("payer")
 								.signedBy("payer", GENESIS)
-								.hasKnownStatus(TOKEN_IS_IMMUTABlE)
+								.hasKnownStatus(TOKEN_IS_IMMUTABLE)
 				);
 	}
 


### PR DESCRIPTION
**Summary of the change**:
Tweak crypto deletion logic and move knownTreasury check up to the CryptoDeleteTranstionLogic.
Also unit tests and bdd.