### PR TITLE
Feat(Scheduled): Add memo field to MerkleSchedule

### DIFF
--- a/hapi-fees/src/main/java/com/hedera/services/usage/schedule/ScheduleCreateUsage.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/schedule/ScheduleCreateUsage.java
@@ -47,8 +47,8 @@ public class ScheduleCreateUsage extends ScheduleTxnUsage<ScheduleCreateUsage> {
 	public FeeData get() {
 		var op = this.op.getScheduleCreate();
 
-		var txBytes = op.getTransactionBody().toByteArray().length;
-		var ramBytes = scheduleEntitySizes.bytesInBaseReprGiven(op.getTransactionBody().toByteArray());
+		var txBytes = op.getTransactionBody().toByteArray().length + op.getMemoBytes().size();
+		var ramBytes = scheduleEntitySizes.bytesInBaseReprGiven(op.getTransactionBody().toByteArray(), op.getMemoBytes());
 		if (op.hasAdminKey()) {
 			long keySize = getAccountKeyStorageSize(op.getAdminKey());
 			txBytes += keySize;

--- a/hapi-fees/src/main/java/com/hedera/services/usage/schedule/ScheduleGetInfoUsage.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/schedule/ScheduleGetInfoUsage.java
@@ -20,6 +20,7 @@ package com.hedera.services.usage.schedule;
  * ‍
  */
 
+import com.google.protobuf.ByteString;
 import com.hedera.services.usage.QueryUsage;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
@@ -50,6 +51,11 @@ public class ScheduleGetInfoUsage extends QueryUsage {
 
 	public ScheduleGetInfoUsage givenTransaction(byte[] transactionBody) {
 		this.updateRb(transactionBody.length);
+		return this;
+	}
+
+	public ScheduleGetInfoUsage givenMemo(ByteString memo) {
+		this.updateRb(memo.size());
 		return this;
 	}
 

--- a/hapi-fees/src/main/java/com/hedera/services/usage/schedule/entities/ScheduleEntitySizes.java
+++ b/hapi-fees/src/main/java/com/hedera/services/usage/schedule/entities/ScheduleEntitySizes.java
@@ -20,6 +20,7 @@ package com.hedera.services.usage.schedule.entities;
  * ‍
  */
 
+import com.google.protobuf.ByteString;
 import com.hederahashgraph.api.proto.java.SignatureMap;
 import com.hederahashgraph.api.proto.java.SignaturePair;
 
@@ -44,23 +45,15 @@ public enum ScheduleEntitySizes {
 				+ NUM_RICH_INSTANT_FIELDS_IN_BASE_SCHEDULE_REPRESENTATION * BASIC_RICH_INSTANT_SIZE;
 	}
 
-	public int bytesInBaseReprGiven(byte[] transactionBody) {
-		return fixedBytesInScheduleRepr() + transactionBody.length;
+	public int bytesInBaseReprGiven(byte[] transactionBody, ByteString memo) {
+		return fixedBytesInScheduleRepr() + transactionBody.length + memo.size();
 	}
 
 	/**
 	 * Signature map is not stored in state, we only need it for bpt
 	 */
 	public int bptScheduleReprGiven(SignatureMap sigMap) {
-		var bytes = 0;
-		for (SignaturePair signaturePair : sigMap.getSigPairList()) {
-			bytes += signaturePair.getPubKeyPrefix().size() +
-					signaturePair.getEd25519().size() +
-					signaturePair.getContract().size() +
-					signaturePair.getRSA3072().size() +
-					signaturePair.getECDSA384().size();
-		}
-		return bytes;
+		return sigMap.toByteArray().length;
 	}
 
 	/**

--- a/hapi-fees/src/test/java/com/hedera/services/usage/schedule/ScheduleCreateUsageTest.java
+++ b/hapi-fees/src/test/java/com/hedera/services/usage/schedule/ScheduleCreateUsageTest.java
@@ -59,6 +59,7 @@ public class ScheduleCreateUsageTest {
 	long now = 1_000L;
 	int scheduledTXExpiry = 1000;
 	AccountID payer = IdUtils.asAccount("0.0.2");
+	String memo = "Just some memo!";
 
 	int numSigs = 3, sigSize = 100, numPayerKeys = 1;
 	SigUsage sigUsage = new SigUsage(numSigs, sigSize, numPayerKeys);
@@ -165,6 +166,29 @@ public class ScheduleCreateUsageTest {
 	}
 
 	@Test
+	public void createsExpectedDeltaForMemo() {
+		// setup:
+		var expectedTxBytes = transactionBody.length + memo.length();
+		var expectedRamBytes = baseRamBytesWithMemo();
+		givenOpWithMemo();
+
+		// and:
+		subject = ScheduleCreateUsage.newEstimate(txn, sigUsage)
+				.givenScheduledTxExpirationTimeSecs(scheduledTXExpiry);
+
+		// when:
+		var actual = subject.get();
+
+		// then:
+		assertEquals(A_USAGES_MATRIX, actual);
+		// and:
+		verify(base).addBpt(expectedTxBytes);
+		verify(base).addRbs(expectedRamBytes * scheduledTXExpiry);
+		verify(base).addVpt(0);
+		verify(base).addNetworkRbs(BASIC_ENTITY_ID_SIZE * USAGE_PROPERTIES.legacyReceiptStorageSecs());
+	}
+
+	@Test
 	public void createsExpectedDeltaForSigMap() {
 		// setup:
 		var expectedTxBytes = transactionBody.length + SCHEDULE_ENTITY_SIZES.bptScheduleReprGiven(sigMap);
@@ -188,7 +212,11 @@ public class ScheduleCreateUsageTest {
 	}
 
 	private long baseRamBytes() {
-		return SCHEDULE_ENTITY_SIZES.bytesInBaseReprGiven(transactionBody);
+		return SCHEDULE_ENTITY_SIZES.bytesInBaseReprGiven(transactionBody, ByteString.EMPTY);
+	}
+
+	private long baseRamBytesWithMemo() {
+		return SCHEDULE_ENTITY_SIZES.bytesInBaseReprGiven(transactionBody, ByteString.copyFromUtf8(memo));
 	}
 
 	private void givenBaseOp() {
@@ -218,6 +246,14 @@ public class ScheduleCreateUsageTest {
 		op = ScheduleCreateTransactionBody.newBuilder()
 				.setTransactionBody(ByteString.copyFrom(transactionBody))
 				.setSigMap(sigMap)
+				.build();
+		setTxn();
+	}
+
+	private void givenOpWithMemo() {
+		op = ScheduleCreateTransactionBody.newBuilder()
+				.setTransactionBody(ByteString.copyFrom(transactionBody))
+				.setMemo(memo)
 				.build();
 		setTxn();
 	}

--- a/hapi-fees/src/test/java/com/hedera/services/usage/schedule/ScheduleGetInfoUsageTest.java
+++ b/hapi-fees/src/test/java/com/hedera/services/usage/schedule/ScheduleGetInfoUsageTest.java
@@ -20,6 +20,7 @@ package com.hedera.services.usage.schedule;
  * ‍
  */
 
+import com.google.protobuf.ByteString;
 import com.hedera.services.test.IdUtils;
 import com.hedera.services.test.KeyUtils;
 import com.hederahashgraph.api.proto.java.Key;
@@ -47,6 +48,7 @@ public class ScheduleGetInfoUsageTest {
 	ScheduleID id = IdUtils.asSchedule("0.0.1");
 	byte[] transactionBody = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09};
 	ScheduleGetInfoUsage subject;
+	ByteString memo = ByteString.copyFromUtf8("This is just a memo?");
 
 	@BeforeEach
 	public void setup() {
@@ -58,13 +60,14 @@ public class ScheduleGetInfoUsageTest {
 		// given:
 		subject.givenCurrentAdminKey(adminKey)
 				.givenSigners(signers)
-				.givenTransaction(transactionBody);
+				.givenTransaction(transactionBody)
+				.givenMemo(memo);
 
 
 		// and:
 		var expectedAdminBytes = FeeBuilder.getAccountKeyStorageSize(adminKey.get());
 		var signersBytes = signers.get().toByteArray().length;
-		var expectedBytes = expectedAdminBytes + signersBytes + SCHEDULE_ENTITY_SIZES.bytesInBaseReprGiven(transactionBody);
+		var expectedBytes = expectedAdminBytes + signersBytes + SCHEDULE_ENTITY_SIZES.bytesInBaseReprGiven(transactionBody, memo);
 
 		// when:
 		var usage = subject.get();

--- a/hapi-fees/src/test/java/com/hedera/services/usage/schedule/entities/ScheduleEntitySizesTest.java
+++ b/hapi-fees/src/test/java/com/hedera/services/usage/schedule/entities/ScheduleEntitySizesTest.java
@@ -20,6 +20,7 @@ package com.hedera.services.usage.schedule.entities;
  * ‍
  */
 
+import com.google.protobuf.ByteString;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
@@ -52,16 +53,18 @@ public class ScheduleEntitySizesTest {
 	}
 
 	@Test
-	public void sizeWithTransactionBodyAsExpected() {
+	public void bytesInBaseReprGivenAsExpected() {
 		// setup:
 		var transactionBody = new byte[]{0x00, 0x01, 0x02, 0x03};
+		var memo = "memo";
 		long expected = NUM_FLAGS_IN_BASE_SCHEDULE_REPRESENTATION * BOOL_SIZE
 				+ NUM_ENTITY_ID_FIELDS_IN_BASE_SCHEDULE_REPRESENTATION * BASIC_ENTITY_ID_SIZE
 				+ NUM_RICH_INSTANT_FIELDS_IN_BASE_SCHEDULE_REPRESENTATION * BASIC_RICH_INSTANT_SIZE
-				+ transactionBody.length;
+				+ transactionBody.length
+				+ memo.length();
 
 		// given:
-		long actual = subject.bytesInBaseReprGiven(transactionBody);
+		long actual = subject.bytesInBaseReprGiven(transactionBody, ByteString.copyFromUtf8(memo));
 
 		// expect:
 		assertEquals(expected, actual);

--- a/hapi-proto/src/main/proto/ScheduleCreate.proto
+++ b/hapi-proto/src/main/proto/ScheduleCreate.proto
@@ -33,4 +33,5 @@ message ScheduleCreateTransactionBody {
   Key adminKey = 2; // (optional) The Key which is able to delete the Scheduled Transaction (if tx is not already executed)
   AccountID payerAccountID = 3; // (optional) The account which is going to pay for the execution of the Scheduled TX. If not populated, the scheduling account is charged
   SignatureMap sigMap = 4; // (optional) Signatures that could be provided (similarly to how signatures are provided in ScheduleSign operation) on Scheduled Transaction creation
+  string memo = 5; // (optional) Publicly visible information about the Scheduled entity, up to 100 bytes. No guarantee of uniqueness.
 }

--- a/hapi-proto/src/main/proto/ScheduleGetInfo.proto
+++ b/hapi-proto/src/main/proto/ScheduleGetInfo.proto
@@ -43,6 +43,7 @@ message ScheduleInfo {
   bytes transactionBody = 4; // The transaction serialized into bytes that must be signed
   KeyList signers = 5; // The keys that have provided signatures so far for the Scheduled TX
   Key adminKey = 6; // The Key which is able to delete the Scheduled Transaction if set
+  string memo = 7; // Publicly visible information about the Scheduled entity, up to 100 bytes. No guarantee of uniqueness.
 }
 
 message ScheduleGetInfoResponse {

--- a/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
+++ b/hedera-node/src/main/java/com/hedera/services/context/ServicesContext.java
@@ -1206,7 +1206,7 @@ public class ServicesContext {
 						List.of(new TokenDissociateTransitionLogic(tokenStore(), txnCtx()))),
 				/* Schedule */
 				entry(ScheduleCreate,
-						List.of(new ScheduleCreateTransitionLogic(scheduleStore(), txnCtx(), activationHelper()))),
+						List.of(new ScheduleCreateTransitionLogic(scheduleStore(), txnCtx(), activationHelper(), validator()))),
 				entry(ScheduleSign,
 						List.of(new ScheduleSignTransitionLogic(scheduleStore(), txnCtx(), activationHelper()))),
 				entry(ScheduleDelete,

--- a/hedera-node/src/main/java/com/hedera/services/fees/calculation/schedule/queries/GetScheduleInfoResourceUsage.java
+++ b/hedera-node/src/main/java/com/hedera/services/fees/calculation/schedule/queries/GetScheduleInfoResourceUsage.java
@@ -74,6 +74,7 @@ public class GetScheduleInfoResourceUsage implements QueryResourceUsageEstimator
 			queryCtx.ifPresent(ctx -> ctx.put(SCHEDULE_INFO_CTX_KEY, info));
 			var estimate = factory.apply(query)
 					.givenTransaction(info.getTransactionBody().toByteArray())
+					.givenMemo(info.getMemoBytes())
 					.givenSigners(ifPresent(info, ScheduleInfo::hasSigners, ScheduleInfo::getSigners))
 					.givenCurrentAdminKey(ifPresent(info, ScheduleInfo::hasAdminKey, ScheduleInfo::getAdminKey));
 			return estimate.get();

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/ExceptionalScheduleStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/ExceptionalScheduleStore.java
@@ -61,7 +61,7 @@ public enum ExceptionalScheduleStore implements ScheduleStore {
 	}
 
 	@Override
-	public CreationResult<ScheduleID> createProvisionally(byte[] bodyBytes, AccountID payer, AccountID schedulingAccount, RichInstant schedulingTXValidStart, Optional<JKey> adminKey) {
+	public CreationResult<ScheduleID> createProvisionally(byte[] bodyBytes, AccountID payer, AccountID schedulingAccount, RichInstant schedulingTXValidStart, Optional<JKey> adminKey, Optional<String> entityMemo) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/HederaScheduleStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/HederaScheduleStore.java
@@ -109,7 +109,7 @@ public class HederaScheduleStore extends HederaStore implements ScheduleStore {
 	}
 
 	@Override
-	public CreationResult<ScheduleID> createProvisionally(byte[] bodyBytes, AccountID payer, AccountID schedulingAccount, RichInstant schedulingTXValidStart, Optional<JKey> adminKey) {
+	public CreationResult<ScheduleID> createProvisionally(byte[] bodyBytes, AccountID payer, AccountID schedulingAccount, RichInstant schedulingTXValidStart, Optional<JKey> adminKey, Optional<String> entityMemo) {
 		var validity = accountCheck(schedulingAccount, INVALID_SCHEDULE_ACCOUNT_ID);
 		if (validity != OK) {
 			return failure(validity);
@@ -125,6 +125,7 @@ public class HederaScheduleStore extends HederaStore implements ScheduleStore {
 				EntityId.ofNullableAccountId(schedulingAccount),
 				schedulingTXValidStart);
 		adminKey.ifPresent(pendingCreation::setAdminKey);
+		entityMemo.ifPresent(pendingCreation::setMemo);
 		pendingCreation.setPayer(EntityId.ofNullableAccountId(payer));
 
 		return success(pendingId);

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/ScheduleStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/ScheduleStore.java
@@ -44,7 +44,7 @@ public interface ScheduleStore extends Store<ScheduleID, MerkleSchedule> {
 
 	void apply(ScheduleID id, Consumer<MerkleSchedule> change);
 
-	CreationResult<ScheduleID> createProvisionally(byte[] bodyBytes, AccountID payer, AccountID schedulingAccount, RichInstant schedulingTXValidStart, Optional<JKey> adminKey);
+	CreationResult<ScheduleID> createProvisionally(byte[] bodyBytes, AccountID payer, AccountID schedulingAccount, RichInstant schedulingTXValidStart, Optional<JKey> adminKey, Optional<String> entityMemo);
 	ResponseCodeEnum addSigners(ScheduleID sID, Set<JKey> keys);
 
 	Optional<ScheduleID> lookupScheduleId(byte[] bodyBytes, AccountID scheduledTxPayer);

--- a/hedera-node/src/test/java/com/hedera/services/fees/calculation/schedule/queries/GetScheduleInfoResourceUsageTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/fees/calculation/schedule/queries/GetScheduleInfoResourceUsageTest.java
@@ -64,6 +64,7 @@ public class GetScheduleInfoResourceUsageTest {
     Key randomKey = new KeyFactory().newEd25519();
     ScheduleInfo info = ScheduleInfo.newBuilder()
             .setTransactionBody(ByteString.copyFrom(new byte[]{0x01, 0x02, 0x03, 0x04}))
+            .setMemo("some memo here")
             .setAdminKey(TxnHandlingScenario.COMPLEX_KEY_ACCOUNT_KT.asKey())
             .setPayerAccountID(TxnHandlingScenario.COMPLEX_KEY_ACCOUNT)
             .setSigners(KeyList.newBuilder().addKeys(randomKey))
@@ -84,6 +85,7 @@ public class GetScheduleInfoResourceUsageTest {
 
 
         given(estimator.givenTransaction(info.getTransactionBody().toByteArray())).willReturn(estimator);
+        given(estimator.givenMemo(info.getMemoBytes())).willReturn(estimator);
         given(estimator.givenCurrentAdminKey(any())).willReturn(estimator);
         given(estimator.givenSigners(any())).willReturn(estimator);
         given(estimator.get()).willReturn(MOCK_SCHEDULE_GET_INFO_USAGE);

--- a/hedera-node/src/test/java/com/hedera/services/store/schedule/ExceptionalScheduleStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/schedule/ExceptionalScheduleStoreTest.java
@@ -33,7 +33,7 @@ class ExceptionalScheduleStoreTest {
     @Test
     public void allButSetAreUse() {
         // expect:
-        assertThrows(UnsupportedOperationException.class, () -> NOOP_SCHEDULE_STORE.createProvisionally(null, null,null, null, null));
+        assertThrows(UnsupportedOperationException.class, () -> NOOP_SCHEDULE_STORE.createProvisionally(null, null,null, null, null, null));
         assertThrows(UnsupportedOperationException.class, () -> NOOP_SCHEDULE_STORE.addSigners(null, null));
         assertThrows(UnsupportedOperationException.class, () -> NOOP_SCHEDULE_STORE.exists(null));
         assertThrows(UnsupportedOperationException.class, () -> NOOP_SCHEDULE_STORE.get(null));

--- a/hedera-node/src/test/java/com/hedera/services/store/schedule/HederaScheduleStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/schedule/HederaScheduleStoreTest.java
@@ -88,6 +88,7 @@ public class HederaScheduleStoreTest {
     MerkleAccount account;
 
     byte[] transactionBody;
+    String entityMemo;
     int transactionBodyHashCode;
     RichInstant schedulingTXValidStart;
     Key adminKey;
@@ -108,6 +109,7 @@ public class HederaScheduleStoreTest {
     @BeforeEach
     public void setup() {
         transactionBody = TxnUtils.randomUtf8Bytes(SIGNATURE_BYTES);
+        entityMemo = "Some memo here";
         transactionBodyHashCode = Arrays.hashCode(transactionBody);
         schedulingTXValidStart = new RichInstant(123, 456);
         adminKey = SCHEDULE_ADMIN_KT.asKey();
@@ -298,6 +300,8 @@ public class HederaScheduleStoreTest {
         var expected = new MerkleSchedule(transactionBody, entitySchedulingAccount, schedulingTXValidStart);
         expected.setAdminKey(adminJKey);
         expected.setPayer(entityPayer);
+        expected.setMemo(entityMemo);
+
         // when:
         var outcome = subject
                 .createProvisionally(
@@ -305,7 +309,8 @@ public class HederaScheduleStoreTest {
                         payerId,
                         schedulingAccount,
                         schedulingTXValidStart,
-                        Optional.of(adminJKey));
+                        Optional.of(adminJKey),
+                        Optional.of(entityMemo));
 
         // then:
         assertEquals(OK, outcome.getStatus());
@@ -324,7 +329,8 @@ public class HederaScheduleStoreTest {
                         null,
                         schedulingAccount,
                         schedulingTXValidStart,
-                        Optional.of(adminJKey));
+                        Optional.of(adminJKey),
+                        Optional.of(entityMemo));
 
         // then:
         assertEquals(INVALID_SCHEDULE_PAYER_ID, outcome.getStatus());
@@ -353,7 +359,8 @@ public class HederaScheduleStoreTest {
                         payerId,
                         schedulingAccount,
                         schedulingTXValidStart,
-                        Optional.of(adminJKey));
+                        Optional.of(adminJKey),
+                        Optional.of(entityMemo));
 
         // then:
         assertEquals(INVALID_SCHEDULE_PAYER_ID, outcome.getStatus());
@@ -375,7 +382,8 @@ public class HederaScheduleStoreTest {
                         payerId,
                         schedulingAccount,
                         schedulingTXValidStart,
-                        Optional.of(adminJKey));
+                        Optional.of(adminJKey),
+                        Optional.of(entityMemo));
 
         // then:
         assertEquals(INVALID_SCHEDULE_PAYER_ID, outcome.getStatus());
@@ -397,7 +405,8 @@ public class HederaScheduleStoreTest {
                         payerId,
                         schedulingAccount,
                         schedulingTXValidStart,
-                        Optional.of(adminJKey));
+                        Optional.of(adminJKey),
+                        Optional.of(entityMemo));
 
         // then:
         assertEquals(INVALID_SCHEDULE_ACCOUNT_ID, outcome.getStatus());
@@ -419,7 +428,8 @@ public class HederaScheduleStoreTest {
                         payerId,
                         schedulingAccount,
                         schedulingTXValidStart,
-                        Optional.of(adminJKey));
+                        Optional.of(adminJKey),
+                        Optional.of(entityMemo));
 
         // then:
         assertEquals(INVALID_SCHEDULE_ACCOUNT_ID, outcome.getStatus());


### PR DESCRIPTION
Signed-off-by: Daniel Ivanov <daniel.k.ivanov95@gmail.com>

**Related issue(s)**:
Closes [#127](https://github.com/LimeChain/hedera-services/issues/127)

**Summary of the change**:
- Adds new memo field in the `MerkleSchedule`
- Adds `memo` to proto `ScheduleCreate` and `ScheduleGetInfo`

**External impacts**:
None.

**Applicable documentation**
- [ ] Javadoc
- [X] HAPI protobuf comments
- [ ] README
