### PR TITLE
Feat/composite key/internal

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/CompositeKey.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/CompositeKey.java
@@ -65,17 +65,12 @@ public class CompositeKey {
 
     @Override
     public final int hashCode() {
-        int result = txBytesHashCode;
-        if (payer != null) {
-            result = 31 * result + payer.hashCode();
-        }
-        if (adminKey != null) {
-            result = 31 * result + adminKey.hashCode();
-        }
-        if (entityMemo != null) {
-            result = 31 * result + entityMemo.hashCode();
-        }
-        return result;
+        return Objects.hash(
+                txBytesHashCode,
+                payer,
+                adminKey,
+                entityMemo
+        );
     }
 
     public static CompositeKey fromMerkleSchedule(MerkleSchedule schedule) {

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/CompositeKey.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/CompositeKey.java
@@ -20,29 +20,29 @@ package com.hedera.services.store.schedule;
  * ‍
  */
 
-import com.hedera.services.legacy.core.jproto.JKey;
 import com.hedera.services.state.merkle.MerkleSchedule;
 import com.hedera.services.state.submerkle.EntityId;
+import com.hederahashgraph.api.proto.java.Key;
 
 import java.util.Arrays;
 import java.util.Objects;
 
-import static com.hedera.services.legacy.core.jproto.JKey.equalUpToDecodability;
+import static com.hedera.services.utils.MiscUtils.asKeyUnchecked;
 
 /**
  * Set of properties used to describe unique instance of Scheduled Transaction
  */
 public class CompositeKey {
 
-    public static final JKey UNUSED_KEY = null;
+    public static final Key UNUSED_KEY = Key.getDefaultInstance();
     private static final String EMPTY_MEMO = null;
 
     private final int txBytesHashCode;
     private final EntityId payer;
-    private final JKey adminKey;
+    private final Key adminKey;
     private final String entityMemo;
 
-    public CompositeKey(int txBytesHashCode, EntityId payer, JKey adminKey, String entityMemo) {
+    public CompositeKey(int txBytesHashCode, EntityId payer, Key adminKey, String entityMemo) {
         this.txBytesHashCode = txBytesHashCode;
         this.payer = payer;
         this.adminKey = adminKey;
@@ -60,7 +60,7 @@ public class CompositeKey {
         return this.txBytesHashCode == other.txBytesHashCode &&
                 Objects.equals(this.entityMemo, other.entityMemo) &&
                 Objects.equals(this.payer, other.payer) &&
-                equalUpToDecodability(this.adminKey, other.adminKey);
+                Objects.equals(this.adminKey, other.adminKey);
     }
 
     @Override
@@ -74,7 +74,7 @@ public class CompositeKey {
     }
 
     public static CompositeKey fromMerkleSchedule(MerkleSchedule schedule) {
-        var adminKey = schedule.adminKey().isPresent() ? schedule.adminKey().get() : UNUSED_KEY;
+        var adminKey = schedule.adminKey().isPresent() ? asKeyUnchecked(schedule.adminKey().get()) : UNUSED_KEY;
         var memo = schedule.memo().isPresent() ? schedule.memo().get() : EMPTY_MEMO;
         return new CompositeKey(
                 Arrays.hashCode(schedule.transactionBody()),

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/ExceptionalScheduleStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/ExceptionalScheduleStore.java
@@ -29,6 +29,7 @@ import com.hedera.services.state.merkle.MerkleSchedule;
 import com.hedera.services.state.submerkle.RichInstant;
 import com.hedera.services.store.CreationResult;
 import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.ScheduleID;
 
@@ -72,7 +73,7 @@ public enum ExceptionalScheduleStore implements ScheduleStore {
 	}
 
 	@Override
-	public Optional<ScheduleID> lookupScheduleId(byte[] bodyBytes, AccountID scheduledTxPayer, Optional<JKey> adminKey, String entityMemo) {
+	public Optional<ScheduleID> lookupScheduleId(byte[] bodyBytes, AccountID scheduledTxPayer, Key adminKey, String entityMemo) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/ExceptionalScheduleStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/ExceptionalScheduleStore.java
@@ -32,6 +32,7 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.ScheduleID;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -71,7 +72,7 @@ public enum ExceptionalScheduleStore implements ScheduleStore {
 	}
 
 	@Override
-	public Optional<ScheduleID> lookupScheduleId(byte[] bodyBytes, AccountID scheduledTxPayer) {
+	public Optional<ScheduleID> lookupScheduleId(byte[] bodyBytes, AccountID scheduledTxPayer, Optional<JKey> adminKey, String entityMemo) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/HederaScheduleStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/HederaScheduleStore.java
@@ -30,6 +30,7 @@ import com.hedera.services.store.CreationResult;
 import com.hedera.services.store.HederaStore;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.ScheduleCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.swirlds.fcmap.FCMap;
 
@@ -219,7 +220,7 @@ public class HederaScheduleStore extends HederaStore implements ScheduleStore {
 	}
 
 	@Override
-	public Optional<ScheduleID> lookupScheduleId(byte[] bodyBytes, AccountID scheduledTxPayer) {
+	public Optional<ScheduleID> lookupScheduleId(ScheduleCreateTransactionBody op) {
 		var keyToCheckFor = new CompositeKey(Arrays.hashCode(bodyBytes), scheduledTxPayer);
 
 		if (isCreationPending()) {

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/HederaScheduleStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/HederaScheduleStore.java
@@ -30,7 +30,6 @@ import com.hedera.services.store.CreationResult;
 import com.hedera.services.store.HederaStore;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.ScheduleCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.swirlds.fcmap.FCMap;
 
@@ -45,6 +44,7 @@ import java.util.function.Supplier;
 import static com.hedera.services.state.merkle.MerkleEntityId.fromScheduleId;
 import static com.hedera.services.store.CreationResult.failure;
 import static com.hedera.services.store.CreationResult.success;
+import static com.hedera.services.store.schedule.CompositeKey.UNUSED_KEY;
 import static com.hedera.services.store.schedule.CompositeKey.fromMerkleSchedule;
 import static com.hedera.services.utils.EntityIdUtils.readableId;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SCHEDULE_ACCOUNT_ID;
@@ -220,8 +220,12 @@ public class HederaScheduleStore extends HederaStore implements ScheduleStore {
 	}
 
 	@Override
-	public Optional<ScheduleID> lookupScheduleId(ScheduleCreateTransactionBody op) {
-		var keyToCheckFor = new CompositeKey(Arrays.hashCode(bodyBytes), scheduledTxPayer);
+	public Optional<ScheduleID> lookupScheduleId(byte[] bodyBytes, AccountID scheduledTxPayer, Optional<JKey> adminKey, String memo) {
+		var keyToCheckFor = new CompositeKey(
+				Arrays.hashCode(bodyBytes),
+				EntityId.ofNullableAccountId(scheduledTxPayer),
+				adminKey.orElse(UNUSED_KEY),
+				memo);
 
 		if (isCreationPending()) {
 			var pendingKey = fromMerkleSchedule(pendingCreation);

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/HederaScheduleStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/HederaScheduleStore.java
@@ -29,6 +29,7 @@ import com.hedera.services.state.submerkle.RichInstant;
 import com.hedera.services.store.CreationResult;
 import com.hedera.services.store.HederaStore;
 import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.swirlds.fcmap.FCMap;
@@ -220,11 +221,11 @@ public class HederaScheduleStore extends HederaStore implements ScheduleStore {
 	}
 
 	@Override
-	public Optional<ScheduleID> lookupScheduleId(byte[] bodyBytes, AccountID scheduledTxPayer, Optional<JKey> adminKey, String memo) {
+	public Optional<ScheduleID> lookupScheduleId(byte[] bodyBytes, AccountID scheduledTxPayer, Key adminKey, String memo) {
 		var keyToCheckFor = new CompositeKey(
 				Arrays.hashCode(bodyBytes),
 				EntityId.ofNullableAccountId(scheduledTxPayer),
-				adminKey.orElse(UNUSED_KEY),
+				adminKey,
 				memo);
 
 		if (isCreationPending()) {

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/ScheduleStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/ScheduleStore.java
@@ -26,6 +26,7 @@ import com.hedera.services.state.submerkle.RichInstant;
 import com.hedera.services.store.CreationResult;
 import com.hedera.services.store.Store;
 import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.ScheduleID;
 
@@ -47,7 +48,7 @@ public interface ScheduleStore extends Store<ScheduleID, MerkleSchedule> {
 	CreationResult<ScheduleID> createProvisionally(byte[] bodyBytes, AccountID payer, AccountID schedulingAccount, RichInstant schedulingTXValidStart, Optional<JKey> adminKey, Optional<String> entityMemo);
 	ResponseCodeEnum addSigners(ScheduleID sID, Set<JKey> keys);
 
-	Optional<ScheduleID> lookupScheduleId(byte[] bodyBytes, AccountID scheduledTxPayer, Optional<JKey> adminKey, String entityMemo);
+	Optional<ScheduleID> lookupScheduleId(byte[] bodyBytes, AccountID scheduledTxPayer, Key adminKey, String entityMemo);
 	ResponseCodeEnum markAsExecuted(ScheduleID id);
 
 	default ScheduleID resolve(ScheduleID id) {

--- a/hedera-node/src/main/java/com/hedera/services/store/schedule/ScheduleStore.java
+++ b/hedera-node/src/main/java/com/hedera/services/store/schedule/ScheduleStore.java
@@ -47,7 +47,7 @@ public interface ScheduleStore extends Store<ScheduleID, MerkleSchedule> {
 	CreationResult<ScheduleID> createProvisionally(byte[] bodyBytes, AccountID payer, AccountID schedulingAccount, RichInstant schedulingTXValidStart, Optional<JKey> adminKey, Optional<String> entityMemo);
 	ResponseCodeEnum addSigners(ScheduleID sID, Set<JKey> keys);
 
-	Optional<ScheduleID> lookupScheduleId(byte[] bodyBytes, AccountID scheduledTxPayer);
+	Optional<ScheduleID> lookupScheduleId(byte[] bodyBytes, AccountID scheduledTxPayer, Optional<JKey> adminKey, String entityMemo);
 	ResponseCodeEnum markAsExecuted(ScheduleID id);
 
 	default ScheduleID resolve(ScheduleID id) {

--- a/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleCreateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleCreateTransitionLogic.java
@@ -85,9 +85,8 @@ public class ScheduleCreateTransitionLogic extends ScheduleReadyForExecution imp
 		var scheduleId = NOT_YET_RESOLVED;
 		byte[] txBytes = op.getTransactionBody().toByteArray();
 		var scheduledPayer = op.hasPayerAccountID() ? op.getPayerAccountID() : txnCtx.activePayer();
-		var adminKey = adminKeyFor(op);
 
-		var extantId = store.lookupScheduleId(txBytes, scheduledPayer, adminKey, op.getMemo());
+		var extantId = store.lookupScheduleId(txBytes, scheduledPayer, op.getAdminKey(), op.getMemo());
 		if (extantId.isPresent()) {
 			scheduleId = extantId.get();
 		} else {
@@ -96,7 +95,7 @@ public class ScheduleCreateTransitionLogic extends ScheduleReadyForExecution imp
 					scheduledPayer,
 					txnCtx.activePayer(),
 					fromJava(txnCtx.consensusTime()),
-					adminKey,
+					adminKeyFor(op),
 					Optional.of(op.getMemo()));
 			if (result.getCreated().isEmpty()) {
 				abortWith(result.getStatus());

--- a/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleCreateTransitionLogic.java
+++ b/hedera-node/src/main/java/com/hedera/services/txns/schedule/ScheduleCreateTransitionLogic.java
@@ -83,18 +83,20 @@ public class ScheduleCreateTransitionLogic extends ScheduleReadyForExecution imp
 
 	private void transitionFor(ScheduleCreateTransactionBody op) throws InvalidProtocolBufferException {
 		var scheduleId = NOT_YET_RESOLVED;
+		byte[] txBytes = op.getTransactionBody().toByteArray();
 		var scheduledPayer = op.hasPayerAccountID() ? op.getPayerAccountID() : txnCtx.activePayer();
+		var adminKey = adminKeyFor(op);
 
-		var extantId = store.lookupScheduleId(op.getTransactionBody().toByteArray(), scheduledPayer);
+		var extantId = store.lookupScheduleId(txBytes, scheduledPayer, adminKey, op.getMemo());
 		if (extantId.isPresent()) {
 			scheduleId = extantId.get();
 		} else {
 			var result = store.createProvisionally(
-					op.getTransactionBody().toByteArray(),
+					txBytes,
 					scheduledPayer,
 					txnCtx.activePayer(),
 					fromJava(txnCtx.consensusTime()),
-					adminKeyFor(op),
+					adminKey,
 					Optional.of(op.getMemo()));
 			if (result.getCreated().isEmpty()) {
 				abortWith(result.getStatus());

--- a/hedera-node/src/test/java/com/hedera/services/store/schedule/CompositeKeyTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/schedule/CompositeKeyTest.java
@@ -57,6 +57,15 @@ public class CompositeKeyTest {
 	}
 
 	@Test
+	public void sameValuesEquals() {
+		// given:
+		var key = new CompositeKey(transactionBodyHashCode, EntityId.ofNullableAccountId(payerId), adminKey, entityMemo);
+		var key2 = new CompositeKey(transactionBodyHashCode, EntityId.ofNullableAccountId(payerId), adminKey, entityMemo);
+
+		assertEquals(key, key2);
+	}
+
+	@Test
 	public void defaultKeyInstanceWorks() {
 		// given:
 		var key1 = new CompositeKey(transactionBodyHashCode, EntityId.ofNullableAccountId(payerId), adminKey, entityMemo);

--- a/hedera-node/src/test/java/com/hedera/services/store/schedule/CompositeKeyTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/schedule/CompositeKeyTest.java
@@ -1,0 +1,76 @@
+package com.hedera.services.store.schedule;
+
+/*
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.services.state.submerkle.EntityId;
+import com.hedera.test.utils.IdUtils;
+import com.hedera.test.utils.TxnUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.Key;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static com.hedera.test.factories.scenarios.TxnHandlingScenario.SCHEDULE_ADMIN_KT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class CompositeKeyTest {
+
+	byte[] transactionBody;
+	int transactionBodyHashCode;
+	Key adminKey = SCHEDULE_ADMIN_KT.asKey();
+	AccountID payerId = IdUtils.asAccount("1.2.456");
+	String entityMemo = "Some memo here";
+
+	@BeforeEach
+	public void setup() {
+		transactionBody = TxnUtils.randomUtf8Bytes(100);
+		transactionBodyHashCode = Arrays.hashCode(transactionBody);
+	}
+
+	@Test
+	public void sameInstanceEquals() {
+		// given:
+		var key = new CompositeKey(transactionBodyHashCode, EntityId.ofNullableAccountId(payerId), adminKey, entityMemo);
+
+		assertEquals(key, key);
+	}
+
+	@Test
+	public void defaultKeyInstanceWorks() {
+		// given:
+		var key1 = new CompositeKey(transactionBodyHashCode, EntityId.ofNullableAccountId(payerId), adminKey, entityMemo);
+		var key2 = new CompositeKey(transactionBodyHashCode, EntityId.ofNullableAccountId(payerId), Key.getDefaultInstance(), entityMemo);
+
+		assertNotEquals(key1, key2);
+	}
+
+	@Test
+	public void equalsWorksWithAnotherObj() {
+		// given:
+		var key = new CompositeKey(transactionBodyHashCode, EntityId.ofNullableAccountId(payerId), adminKey, entityMemo);
+
+		assertNotEquals(key, new Object());
+	}
+
+}

--- a/hedera-node/src/test/java/com/hedera/services/store/schedule/CompositeKeyTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/schedule/CompositeKeyTest.java
@@ -57,12 +57,13 @@ public class CompositeKeyTest {
 	}
 
 	@Test
-	public void sameValuesEquals() {
+	public void equalsAndHashCodeAreSymmetric() {
 		// given:
 		var key = new CompositeKey(transactionBodyHashCode, EntityId.ofNullableAccountId(payerId), adminKey, entityMemo);
 		var key2 = new CompositeKey(transactionBodyHashCode, EntityId.ofNullableAccountId(payerId), adminKey, entityMemo);
 
 		assertEquals(key, key2);
+		assertEquals(key.hashCode(), key2.hashCode());
 	}
 
 	@Test

--- a/hedera-node/src/test/java/com/hedera/services/store/schedule/ExceptionalScheduleStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/schedule/ExceptionalScheduleStoreTest.java
@@ -40,7 +40,7 @@ class ExceptionalScheduleStoreTest {
         assertThrows(UnsupportedOperationException.class, NOOP_SCHEDULE_STORE::commitCreation);
         assertThrows(UnsupportedOperationException.class, NOOP_SCHEDULE_STORE::rollbackCreation);
         assertThrows(UnsupportedOperationException.class, NOOP_SCHEDULE_STORE::isCreationPending);
-        assertThrows(UnsupportedOperationException.class, () -> NOOP_SCHEDULE_STORE.lookupScheduleId(null, null));
+        assertThrows(UnsupportedOperationException.class, () -> NOOP_SCHEDULE_STORE.lookupScheduleId(null, null, null, null));
         // and:
         assertDoesNotThrow(() -> NOOP_SCHEDULE_STORE.setAccountsLedger(null));
         assertDoesNotThrow(() -> NOOP_SCHEDULE_STORE.setHederaLedger(null));

--- a/hedera-node/src/test/java/com/hedera/services/store/schedule/HederaScheduleStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/store/schedule/HederaScheduleStoreTest.java
@@ -460,13 +460,12 @@ public class HederaScheduleStoreTest {
         CompositeKey txKey = new CompositeKey(
                 transactionBodyHashCode,
                 EntityId.ofNullableAccountId(payerId),
-                adminJKey,
+                adminKey,
                 entityMemo);
         subject.txToEntityId.put(txKey, fromScheduleId(created));
-        given(subject.get(created)).willReturn(schedule);
 
         // when:
-        var scheduleId = subject.lookupScheduleId(transactionBody, payerId, Optional.of(adminJKey), entityMemo);
+        var scheduleId = subject.lookupScheduleId(transactionBody, payerId, adminKey, entityMemo);
 
         assertEquals(Optional.of(created), scheduleId);
     }
@@ -478,7 +477,7 @@ public class HederaScheduleStoreTest {
         subject.pendingId = created;
 
         // when:
-        var scheduleId = subject.lookupScheduleId(transactionBody, payerId, Optional.of(adminJKey), entityMemo);
+        var scheduleId = subject.lookupScheduleId(transactionBody, payerId, adminKey, entityMemo);
 
         assertEquals(Optional.of(created), scheduleId);
     }
@@ -486,7 +485,7 @@ public class HederaScheduleStoreTest {
     @Test
     public void failsToGetScheduleID() {
         // when:
-        var scheduleId = subject.lookupScheduleId(transactionBody, payerId, Optional.of(adminJKey), entityMemo);
+        var scheduleId = subject.lookupScheduleId(transactionBody, payerId, adminKey, entityMemo);
 
         assertTrue(scheduleId.isEmpty());
     }
@@ -525,22 +524,6 @@ public class HederaScheduleStoreTest {
 
         // then:
         assertEquals(INVALID_SCHEDULE_ID, outcome);
-    }
-
-    @Test
-    public void validCompositeKey() {
-        // given:
-        var key = new CompositeKey(transactionBodyHashCode, EntityId.ofNullableAccountId(payerId), adminJKey, entityMemo);
-
-        assertEquals(key, key);
-    }
-
-    @Test
-    public void validDifferentInstanceKey() {
-        // given:
-        var key = new CompositeKey(transactionBodyHashCode, EntityId.ofNullableAccountId(payerId), adminJKey, entityMemo);
-
-        assertNotEquals(key, new Object());
     }
 
     @Test

--- a/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleCreateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleCreateTransitionLogicTest.java
@@ -146,7 +146,7 @@ public class ScheduleCreateTransitionLogicTest {
 		verify(store).lookupScheduleId(
 				eq(transactionBody),
 				eq(payer),
-				argThat((Optional<JKey> k) -> equalUpToDecodability(k.get(), jAdminKey.get())),
+				eq(key),
 				argThat((String memo) -> Objects.equals(memo, entityMemo)));
 
 		// and:
@@ -176,7 +176,7 @@ public class ScheduleCreateTransitionLogicTest {
 		given(store.lookupScheduleId(
 				eq(transactionBody),
 				eq(payer),
-				argThat((Optional<JKey> k) -> equalUpToDecodability(k.get(), jAdminKey.get())),
+				eq(key),
 				argThat((String m) -> m.equals(entityMemo))))
 				.willReturn(Optional.of(schedule));
 		given(store.get(schedule)).willReturn(created);
@@ -189,7 +189,7 @@ public class ScheduleCreateTransitionLogicTest {
 		verify(store).lookupScheduleId(
 				eq(transactionBody),
 				eq(payer),
-				argThat((Optional<JKey> k) -> equalUpToDecodability(k.get(), jAdminKey.get())),
+				eq(key),
 				argThat((String memo) -> Objects.equals(memo, entityMemo)));
 
 		// and:
@@ -219,7 +219,7 @@ public class ScheduleCreateTransitionLogicTest {
 		verify(store).lookupScheduleId(
 				eq(transactionBody),
 				eq(payer),
-				argThat((Optional<JKey> k) -> equalUpToDecodability(k.get(), jAdminKey.get())),
+				eq(key),
 				argThat((String memo) -> Objects.equals(memo, entityMemo)));
 
 		// and:
@@ -244,7 +244,7 @@ public class ScheduleCreateTransitionLogicTest {
 		given(store.lookupScheduleId(
 				eq(transactionBody),
 				eq(payer),
-				argThat((Optional<JKey> k) -> equalUpToDecodability(k.get(), jAdminKey.get())),
+				eq(key),
 				argThat((String m) -> m.equals(entityMemo)))).willReturn(EMPTY_SCHEDULE);
 		given(store.createProvisionally(
 				eq(transactionBody),
@@ -261,7 +261,7 @@ public class ScheduleCreateTransitionLogicTest {
 		verify(store).lookupScheduleId(
 				eq(transactionBody),
 				eq(payer),
-				argThat((Optional<JKey> k) -> equalUpToDecodability(k.get(), jAdminKey.get())),
+				eq(key),
 				argThat((String memo) -> Objects.equals(memo, entityMemo)));
 
 		// and:
@@ -283,7 +283,7 @@ public class ScheduleCreateTransitionLogicTest {
 		given(store.lookupScheduleId(
 				eq(transactionBody),
 				eq(payer),
-				argThat((Optional<JKey> k) -> equalUpToDecodability(k.get(), jAdminKey.get())),
+				eq(key),
 				argThat((String m) -> m.equals(entityMemo))))
 				.willThrow(IllegalArgumentException.class);
 
@@ -294,7 +294,7 @@ public class ScheduleCreateTransitionLogicTest {
 		verify(store).lookupScheduleId(
 				eq(transactionBody),
 				eq(payer),
-				argThat((Optional<JKey> k) -> equalUpToDecodability(k.get(), jAdminKey.get())),
+				eq(key),
 				argThat((String memo) -> Objects.equals(memo, entityMemo)));
 		// and:
 		verify(txnCtx).setStatus(FAIL_INVALID);
@@ -381,7 +381,7 @@ public class ScheduleCreateTransitionLogicTest {
 		given(txnCtx.activePayer()).willReturn(payer);
 		given(txnCtx.consensusTime()).willReturn(now);
 		given(store.isCreationPending()).willReturn(true);
-		given(store.lookupScheduleId(transactionBody, payer, jAdminKey, entityMemo)).willReturn(EMPTY_SCHEDULE);
+		given(store.lookupScheduleId(transactionBody, payer, key, entityMemo)).willReturn(EMPTY_SCHEDULE);
 		given(store.createProvisionally(
 				eq(transactionBody),
 				eq(payer),

--- a/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleCreateTransitionLogicTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/txns/schedule/ScheduleCreateTransitionLogicTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.hedera.services.legacy.core.jproto.JKey.equalUpToDecodability;
@@ -142,7 +143,12 @@ public class ScheduleCreateTransitionLogicTest {
 		subject.doStateTransition();
 
 		// then:
-		verify(store).lookupScheduleId(transactionBody, payer);
+		verify(store).lookupScheduleId(
+				eq(transactionBody),
+				eq(payer),
+				argThat((Optional<JKey> k) -> equalUpToDecodability(k.get(), jAdminKey.get())),
+				argThat((String memo) -> Objects.equals(memo, entityMemo)));
+
 		// and:
 		verify(store).createProvisionally(
 				eq(transactionBody),
@@ -167,7 +173,12 @@ public class ScheduleCreateTransitionLogicTest {
 		given(created.transactionBody()).willReturn(transactionBody);
 
 		// and:
-		given(store.lookupScheduleId(transactionBody, payer)).willReturn(Optional.of(schedule));
+		given(store.lookupScheduleId(
+				eq(transactionBody),
+				eq(payer),
+				argThat((Optional<JKey> k) -> equalUpToDecodability(k.get(), jAdminKey.get())),
+				argThat((String m) -> m.equals(entityMemo))))
+				.willReturn(Optional.of(schedule));
 		given(store.get(schedule)).willReturn(created);
 		given(store.isCreationPending()).willReturn(false);
 
@@ -175,7 +186,12 @@ public class ScheduleCreateTransitionLogicTest {
 		subject.doStateTransition();
 
 		// then:
-		verify(store).lookupScheduleId(transactionBody, payer);
+		verify(store).lookupScheduleId(
+				eq(transactionBody),
+				eq(payer),
+				argThat((Optional<JKey> k) -> equalUpToDecodability(k.get(), jAdminKey.get())),
+				argThat((String memo) -> Objects.equals(memo, entityMemo)));
+
 		// and:
 		verify(store, never()).createProvisionally(eq(transactionBody),
 				eq(payer),
@@ -200,7 +216,12 @@ public class ScheduleCreateTransitionLogicTest {
 		subject.doStateTransition();
 
 		// then:
-		verify(store).lookupScheduleId(transactionBody, payer);
+		verify(store).lookupScheduleId(
+				eq(transactionBody),
+				eq(payer),
+				argThat((Optional<JKey> k) -> equalUpToDecodability(k.get(), jAdminKey.get())),
+				argThat((String memo) -> Objects.equals(memo, entityMemo)));
+
 		// and:
 		verify(store).createProvisionally(
 				eq(transactionBody),
@@ -220,7 +241,11 @@ public class ScheduleCreateTransitionLogicTest {
 		givenValidTxnCtx();
 
 		// and:
-		given(store.lookupScheduleId(transactionBody, payer)).willReturn(EMPTY_SCHEDULE);
+		given(store.lookupScheduleId(
+				eq(transactionBody),
+				eq(payer),
+				argThat((Optional<JKey> k) -> equalUpToDecodability(k.get(), jAdminKey.get())),
+				argThat((String m) -> m.equals(entityMemo)))).willReturn(EMPTY_SCHEDULE);
 		given(store.createProvisionally(
 				eq(transactionBody),
 				eq(payer),
@@ -233,7 +258,12 @@ public class ScheduleCreateTransitionLogicTest {
 		subject.doStateTransition();
 
 		// then:
-		verify(store).lookupScheduleId(transactionBody, payer);
+		verify(store).lookupScheduleId(
+				eq(transactionBody),
+				eq(payer),
+				argThat((Optional<JKey> k) -> equalUpToDecodability(k.get(), jAdminKey.get())),
+				argThat((String memo) -> Objects.equals(memo, entityMemo)));
+
 		// and:
 		verify(store).createProvisionally(
 				eq(transactionBody),
@@ -250,13 +280,22 @@ public class ScheduleCreateTransitionLogicTest {
 	public void setsFailInvalidIfUnhandledException() {
 		givenValidTxnCtx();
 		// and:
-		given(store.lookupScheduleId(transactionBody, payer)).willThrow(IllegalArgumentException.class);
+		given(store.lookupScheduleId(
+				eq(transactionBody),
+				eq(payer),
+				argThat((Optional<JKey> k) -> equalUpToDecodability(k.get(), jAdminKey.get())),
+				argThat((String m) -> m.equals(entityMemo))))
+				.willThrow(IllegalArgumentException.class);
 
 		// when:
 		subject.doStateTransition();
 
 		// then:
-		verify(store).lookupScheduleId(transactionBody, payer);
+		verify(store).lookupScheduleId(
+				eq(transactionBody),
+				eq(payer),
+				argThat((Optional<JKey> k) -> equalUpToDecodability(k.get(), jAdminKey.get())),
+				argThat((String memo) -> Objects.equals(memo, entityMemo)));
 		// and:
 		verify(txnCtx).setStatus(FAIL_INVALID);
 	}
@@ -342,7 +381,7 @@ public class ScheduleCreateTransitionLogicTest {
 		given(txnCtx.activePayer()).willReturn(payer);
 		given(txnCtx.consensusTime()).willReturn(now);
 		given(store.isCreationPending()).willReturn(true);
-		given(store.lookupScheduleId(transactionBody, payer)).willReturn(EMPTY_SCHEDULE);
+		given(store.lookupScheduleId(transactionBody, payer, jAdminKey, entityMemo)).willReturn(EMPTY_SCHEDULE);
 		given(store.createProvisionally(
 				eq(transactionBody),
 				eq(payer),

--- a/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -110,6 +110,7 @@ import static com.hedera.services.bdd.suites.HapiApiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiApiSuite.EXCHANGE_RATE_CONTROL;
 import static com.hedera.services.bdd.suites.HapiApiSuite.SYSTEM_ADMIN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
+import static org.junit.Assert.assertEquals;
 
 public class UtilVerbs {
 	public static HapiFreeze freeze() {
@@ -297,7 +298,7 @@ public class UtilVerbs {
 	}
 
 	public static HapiSpecOperation chunkAFile(String filePath, int chunkSize, String payer, String topic,
-			AtomicLong count) {
+											   AtomicLong count) {
 		return withOpContext((spec, ctxLog) -> {
 			List<HapiSpecOperation> opsList = new ArrayList<HapiSpecOperation>();
 			String overriddenFile = new String(filePath);
@@ -710,5 +711,16 @@ public class UtilVerbs {
 	public static boolean isNotThrottleProp(Setting setting) {
 		var name = setting.getName();
 		return !name.startsWith("hapi.throttling");
+	}
+
+	public static HapiSpecOperation ensureIdempotentlyCreated(String txId, String otherTxId) {
+		return withOpContext((spec, opLog) -> {
+			var firstTx = getTxnRecord(txId);
+			var secondTx = getTxnRecord(otherTxId);
+			allRunFor(spec, firstTx, secondTx);
+			assertEquals(
+					firstTx.getResponseRecord().getReceipt().getScheduleID(),
+					secondTx.getResponseRecord().getReceipt().getScheduleID());
+		});
 	}
 }

--- a/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
+++ b/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
@@ -301,20 +301,21 @@ public class ScheduleCreateSpecs extends HapiApiSuite {
 	}
 
 	private HapiApiSpec idempotentCreationWhenAllPropsAreTheSame() {
-		var txnBody = cryptoCreate("primaryCrypto");
-		return defaultHapiSpec("AllowsScheduledTransactionsWithDuplicatingBodyPayerAndAdmin")
+		var txnBody = cryptoTransfer(tinyBarsFromTo("payer", "receiver", 1));
+		return defaultHapiSpec("IdempotentCreationWhenAllPropsAreTheSame")
 				.given(
 						cryptoCreate("payer"),
+						cryptoCreate("receiver"),
 						newKeyNamed("admin"),
 						scheduleCreate("first", txnBody)
-								.adminKey("admin")
 								.payer("payer")
+								.adminKey("admin")
 								.withEntityMemo("memo here")
 								.via("first")
 				).when(
 						scheduleCreate("second", txnBody)
-								.adminKey("admin")
 								.payer("payer")
+								.adminKey("admin")
 								.withEntityMemo("memo here")
 								.via("second")
 				).then(
@@ -327,12 +328,12 @@ public class ScheduleCreateSpecs extends HapiApiSuite {
 									secondTx.getResponseRecord().getReceipt().getScheduleID());
 						}),
 						getScheduleInfo("first")
-								.hasAdminKey("admin")
 								.hasPayerAccountID("payer")
+								.hasAdminKey("admin")
 								.hasEntityMemo("memo here"),
 						getScheduleInfo("second")
-								.hasAdminKey("admin")
 								.hasPayerAccountID("payer")
+								.hasAdminKey("admin")
 								.hasEntityMemo("memo here")
 				);
 	}


### PR DESCRIPTION
**Related issue(s)**:
Closes #143 

**Summary of the change**:
- Refactors the `CompositeKey` to include all properties of the ScheduleCreate op except for the sigmap
- Added/updated unit tests
- Added BDDs

**Applicable documentation**
- [ ] Javadoc
- [ ] HAPI protobuf comments
- [ ] README
