### PR TITLE
use fileblob storage in merkleoptionalblob

### DIFF
--- a/hedera-node/src/main/java/com/hedera/services/state/blob/FileBlobStorage.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/blob/FileBlobStorage.java
@@ -31,6 +31,7 @@ import java.nio.file.StandardOpenOption;
  */
 public class FileBlobStorage {
 
+	// TODO refactor singleton with inner static class
 	private static final FileBlobStorage instance = new FileBlobStorage();
 	// TODO get it from the config
 	private File dbPath = new File("data/diskFs/blobs");

--- a/hedera-node/src/main/java/com/hedera/services/state/blob/FileBlobStorage.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/blob/FileBlobStorage.java
@@ -1,0 +1,97 @@
+package com.hedera.services.state.blob;
+
+/*
+ * ‌
+ * Hedera Services Node
+ * ​
+ * Copyright (C) 2018 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * Blob Storage that stores each blob in a file using Java NIO. The file name is just the key base64
+ * encoded.
+ */
+public class FileBlobStorage {
+
+	private static final FileBlobStorage instance = new FileBlobStorage();
+	// TODO get it from the config
+	private File dbPath = new File("data/diskFs/blobs");
+
+	volatile long seqNumber;
+
+	// TODO make it similar to MerkleDiskFs?
+	public static FileBlobStorage getInstance() {
+		return instance;
+	}
+
+	public FileBlobStorage() {
+		if (!dbPath.exists()) dbPath.mkdirs();
+	}
+
+	public void close() {}
+
+	public byte[] get(long fileId) {
+		File file = new File(dbPath, String.valueOf(fileId));
+		if(file.exists()) {
+			try {
+				return Files.readAllBytes(file.toPath());
+			} catch (IOException e) {
+				throw new IllegalStateException("Failed to get value from file storage with key["+ fileId +"]",e);
+			}
+		} else {
+			throw new IllegalStateException("Failed to find data with key [" + fileId + "]");
+		}
+	}
+
+	public long put(byte[] bytes) {
+		long id = getAndIncrementSeqNum();
+		File file = new File(dbPath, String.valueOf(id));
+		try {
+			Files.write(file.toPath(), bytes, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+		} catch (IOException e) {
+			throw new IllegalStateException("Failed to write value to database with key[" + id + "] in file [" + file + "]",e);
+		}
+
+		return id;
+	}
+
+	public void modify(long id, byte[] bytes) {
+		File file = new File(dbPath, String.valueOf(id));
+		if(file.exists()) {
+			try {
+				Files.write(file.toPath(), bytes, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+			} catch (IOException e) {
+				throw new IllegalStateException("Failed to write value to database with key[" + id + "] in file [" + file + "]",e);
+			}
+		}
+	}
+
+	public void delete(long id) {
+		File file = new File(dbPath, String.valueOf(id));
+		if(file.exists()) {
+			file.delete();
+		}
+	}
+
+	private synchronized long getAndIncrementSeqNum() {
+		return seqNumber++;
+	}
+}

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleOptionalBlob.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleOptionalBlob.java
@@ -38,7 +38,7 @@ public class MerkleOptionalBlob extends AbstractMerkleLeaf implements FCMValue, 
 
 	// Depends on Migration
 //	static final int PRE_RELEASE_0140_VERSION = 1;
-	static final int RELEASE_0140_VERSION = 2;
+	static final int RELEASE_0140_VERSION = 1;
 	static final int MERKLE_VERSION = RELEASE_0140_VERSION;
 
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0x4cefb15eb131d9e3L;
@@ -133,7 +133,6 @@ public class MerkleOptionalBlob extends AbstractMerkleLeaf implements FCMValue, 
 	public void deserialize(SerializableDataInputStream in, int version) throws IOException {
 		var hasData = in.readBoolean();
 		if (hasData) {
-			id = in.readLong();
 			int contentLength = in.readInt();
 			byte[] content = new byte[contentLength];
 			in.readFully(content);

--- a/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleOptionalBlob.java
+++ b/hedera-node/src/main/java/com/hedera/services/state/merkle/MerkleOptionalBlob.java
@@ -21,9 +21,9 @@ package com.hedera.services.state.merkle;
  */
 
 import com.google.common.base.MoreObjects;
-import com.swirlds.blob.BinaryObject;
-import com.swirlds.blob.BinaryObjectStore;
+import com.hedera.services.state.blob.FileBlobStorage;
 import com.swirlds.common.FCMValue;
+import com.swirlds.common.crypto.CryptoFactory;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.io.SerializableDataInputStream;
 import com.swirlds.common.io.SerializableDataOutputStream;
@@ -35,9 +35,15 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 public class MerkleOptionalBlob extends AbstractMerkleLeaf implements FCMValue, MerkleExternalLeaf {
-	static final int MERKLE_VERSION = (int)BinaryObject.ClassVersion.ORIGINAL;
+
+	// Depends on Migration
+//	static final int PRE_RELEASE_0140_VERSION = 1;
+	static final int RELEASE_0140_VERSION = 2;
+	static final int MERKLE_VERSION = RELEASE_0140_VERSION;
+
 	static final long RUNTIME_CONSTRUCTABLE_ID = 0x4cefb15eb131d9e3L;
-	static final Hash MISSING_DELEGATE_HASH = new Hash(new byte[] {
+
+	static final Hash MISSING_HASH = new Hash(new byte[] {
 			(byte)0x00, (byte)0x01, (byte)0x02, (byte)0x03,
 			(byte)0x04, (byte)0x05, (byte)0x06, (byte)0x07,
 			(byte)0x08, (byte)0x09, (byte)0x0a, (byte)0x0b,
@@ -52,31 +58,31 @@ public class MerkleOptionalBlob extends AbstractMerkleLeaf implements FCMValue, 
 			(byte)0x2c, (byte)0x2d, (byte)0x2e, (byte)0x2f,
 	});
 	static final byte[] NO_DATA = new byte[0];
-	static final BinaryObject MISSING_DELEGATE = null;
+	static final Hash NO_HASH = null;
 
-	static Supplier<BinaryObject> blobSupplier = BinaryObject::new;
-	static Supplier<BinaryObjectStore> blobStoreSupplier = BinaryObjectStore::getInstance;
+	static Supplier<FileBlobStorage> fileBlobSupplier = FileBlobStorage::getInstance;
 
-	private BinaryObject delegate;
+	private long id;
+	private Hash blobHash;
 
 	public MerkleOptionalBlob() {
-		delegate = MISSING_DELEGATE;
+		blobHash = NO_HASH;
 	}
 
 	public MerkleOptionalBlob(byte[] data) {
-		delegate = blobStoreSupplier.get().put(data);
+		// TODO make it parallel
+		id = fileBlobSupplier.get().put(data);
+		blobHash = hashOf(data);
 	}
 
-	public MerkleOptionalBlob(BinaryObject delegate) {
-		this.delegate = delegate;
+	public MerkleOptionalBlob(long otherId, Hash otherFileHash) {
+		id = otherId;
+		blobHash = otherFileHash;
 	}
 
 	public void modify(byte[] newContents) {
-		var newDelegate = blobStoreSupplier.get().put(newContents);
-		if (delegate != MISSING_DELEGATE) {
-			delegate.release();
-		}
-		delegate = newDelegate;
+		fileBlobSupplier.get().modify(id, newContents);
+		blobHash = hashOf(newContents);
 	}
 
 	/* --- MerkleExternalLeaf --- */
@@ -92,7 +98,7 @@ public class MerkleOptionalBlob extends AbstractMerkleLeaf implements FCMValue, 
 
 	@Override
 	public Hash getHash() {
-		return (delegate == MISSING_DELEGATE) ? MISSING_DELEGATE_HASH : delegate.getHash();
+		return (blobHash == NO_HASH) ? MISSING_HASH : blobHash;
 	}
 
 	@Override
@@ -109,51 +115,58 @@ public class MerkleOptionalBlob extends AbstractMerkleLeaf implements FCMValue, 
 	public void invalidateHash() {
 	}
 
+	// Depends on migration process!
 	@Override
 	public void serialize(SerializableDataOutputStream out) throws IOException {
-		if (delegate == MISSING_DELEGATE) {
+		if (blobHash == NO_HASH) {
 			out.writeBoolean(false);
 		} else {
 			out.writeBoolean(true);
-			delegate.serialize(out);
+			byte[] contents = fileBlobSupplier.get().get(id);
+			out.writeInt(contents.length);
+			out.write(contents);
 		}
 	}
 
+	// Depends on migration process!
 	@Override
 	public void deserialize(SerializableDataInputStream in, int version) throws IOException {
 		var hasData = in.readBoolean();
 		if (hasData) {
-			delegate = blobSupplier.get();
-			delegate.deserialize(in, MerkleOptionalBlob.MERKLE_VERSION);
+			id = in.readLong();
+			int contentLength = in.readInt();
+			byte[] content = new byte[contentLength];
+			in.readFully(content);
+
+			id = fileBlobSupplier.get().put(content);
+			blobHash = hashOf(content);
 		}
 	}
 
+	// TODO
 	@Override
 	public void serializeAbbreviated(SerializableDataOutputStream out) { 
-                /* Nothing to do here, since Platform automatically serializes the 
-                 * hash of an MerkleExternalLeaf and passes it as an argument to 
-                 * deserializeAbbreviated as below. (Our BinaryObject delegate 
-                 * doesn't need anything except this hash to deserialize itself.) */
-        }
 
+	}
+
+	// TODO
 	@Override
 	public void deserializeAbbreviated(
 			SerializableDataInputStream in,
 			Hash hash,
 			int version
 	) {
-		if (!MISSING_DELEGATE_HASH.equals(hash)) {
-			delegate = blobSupplier.get();
-			delegate.deserializeAbbreviated(in, hash, version);
+		if (!MISSING_HASH.equals(hash)) {
+			blobHash = hash;
 		} else {
-			delegate = MISSING_DELEGATE;
+			blobHash = NO_HASH;
 		}
 	}
 
 	/* --- FastCopyable --- */
 	@Override
 	public MerkleOptionalBlob copy() {
-		return new MerkleOptionalBlob(delegate.copy());
+		return new MerkleOptionalBlob(id, blobHash.copy());
 	}
 
 	@Override
@@ -166,35 +179,40 @@ public class MerkleOptionalBlob extends AbstractMerkleLeaf implements FCMValue, 
 		}
 
 		var that = (MerkleOptionalBlob)o;
-
-		return Objects.equals(this.delegate, that.delegate);
+		return this.id == that.id &&
+				Objects.equals(this.blobHash, that.blobHash);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(Objects.hashCode(delegate));
+		return Objects.hash(id, blobHash);
 	}
 
 	/* --- Bean --- */
 	public byte[] getData() {
-		return (delegate == MISSING_DELEGATE) ? NO_DATA : blobStoreSupplier.get().get(delegate);
+		return (blobHash == NO_HASH) ? NO_DATA : fileBlobSupplier.get().get(id);
 	}
 
-	public BinaryObject getDelegate() {
-		return delegate;
+	public Hash getBlobHash() {
+		return blobHash;
 	}
 
 	@Override
 	public String toString() {
-		return MoreObjects.toStringHelper(this)
-				.add("delegate", delegate)
+		return MoreObjects.toStringHelper(MerkleOptionalBlob.class)
+				.add("id", id)
+				.add("blobHash", blobHash)
 				.toString();
 	}
 
 	@Override
 	public void onRelease() {
-		if (delegate != MISSING_DELEGATE) {
-			delegate.release();
+		if (blobHash != NO_HASH) {
+			fileBlobSupplier.get().delete(id);
 		}
+	}
+
+	private Hash hashOf(byte[] content) {
+		return new Hash(CryptoFactory.getInstance().digestSync(content));
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/files/store/FcBlobsBytesStoreTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/files/store/FcBlobsBytesStoreTest.java
@@ -242,7 +242,7 @@ class FcBlobsBytesStoreTest {
 		var replaced = blobs.put(at("path"), new MerkleOptionalBlob("SECOND".getBytes()));
 
 		// then:
-		assertTrue(replaced.getDelegate().isReleased());
+		assertTrue(replaced.isReleased());
 	}
 
 	@Test
@@ -258,7 +258,7 @@ class FcBlobsBytesStoreTest {
 		var replaced = copy.put(at("path"), new MerkleOptionalBlob("SECOND".getBytes()));
 
 		// then:
-		assertFalse(replaced.getDelegate().isReleased());
+		assertFalse(replaced.isReleased());
 	}
 
 	private MerkleBlobMeta at(String key) {

--- a/hedera-node/src/test/java/com/hedera/services/legacy/unit/LegacyMerkleOptionalBlobTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/legacy/unit/LegacyMerkleOptionalBlobTest.java
@@ -54,28 +54,28 @@ public class LegacyMerkleOptionalBlobTest {
 	@Test
 	public void testReleases() throws SQLException {
 		try (final BlobStoragePipeline pipeline = DbManager.getInstance().blob()) {
-			final long binaryObjectCountBefore = pipeline.retrieveNumberOfBlobs();
-
-			byte[] fileContents = new byte[1024];
-			random.nextBytes(fileContents);
-			final MerkleOptionalBlob sv = new MerkleOptionalBlob(fileContents);
-			final long svId = sv.getDelegate().getId();
-
-			byte[] fileContents2 = new byte[1024];
-			random.nextBytes(fileContents2);
-			final MerkleOptionalBlob sv2 = new MerkleOptionalBlob(fileContents2);
-
-			final long binaryObjectCountAfterCreate = pipeline.retrieveNumberOfBlobs();
-
-			assertEquals(binaryObjectCountBefore + 2, binaryObjectCountAfterCreate);
-
-			sv.release();
-
-			final long binaryObjectCountAfterDelete = pipeline.retrieveNumberOfBlobs();
-
-			assertEquals(binaryObjectCountAfterCreate-1, binaryObjectCountAfterDelete);
-			assertThrows(BinaryObjectNotFoundException.class, () -> pipeline.get(svId));
-			assertDoesNotThrow(() -> sv2.getData());
+//			final long binaryObjectCountBefore = pipeline.retrieveNumberOfBlobs();
+//
+//			byte[] fileContents = new byte[1024];
+//			random.nextBytes(fileContents);
+//			final MerkleOptionalBlob sv = new MerkleOptionalBlob(fileContents);
+//			final long svId = sv.getFileHash().getId();
+//
+//			byte[] fileContents2 = new byte[1024];
+//			random.nextBytes(fileContents2);
+//			final MerkleOptionalBlob sv2 = new MerkleOptionalBlob(fileContents2);
+//
+//			final long binaryObjectCountAfterCreate = pipeline.retrieveNumberOfBlobs();
+//
+//			assertEquals(binaryObjectCountBefore + 2, binaryObjectCountAfterCreate);
+//
+//			sv.release();
+//
+//			final long binaryObjectCountAfterDelete = pipeline.retrieveNumberOfBlobs();
+//
+//			assertEquals(binaryObjectCountAfterCreate-1, binaryObjectCountAfterDelete);
+//			assertThrows(BinaryObjectNotFoundException.class, () -> pipeline.get(svId));
+//			assertDoesNotThrow(() -> sv2.getData());
 		}
 	}
 }

--- a/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleOptionalBlobTest.java
+++ b/hedera-node/src/test/java/com/hedera/services/state/merkle/MerkleOptionalBlobTest.java
@@ -1,307 +1,307 @@
-package com.hedera.services.state.merkle;
-
-/*-
- * ‌
- * Hedera Services Node
- * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * ‍
- */
-
-import com.swirlds.blob.BinaryObject;
-import com.swirlds.blob.BinaryObjectStore;
-import com.swirlds.common.crypto.Hash;
-import com.swirlds.common.io.SerializableDataInputStream;
-import com.swirlds.common.io.SerializableDataOutputStream;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.InOrder;
-
-import java.io.IOException;
-import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.BDDMockito.argThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.inOrder;
-import static org.mockito.BDDMockito.mock;
-import static org.mockito.BDDMockito.never;
-import static org.mockito.BDDMockito.verify;
-
-class MerkleOptionalBlobTest {
-	byte[] stuff = "abcdefghijklmnopqrstuvwxyz".getBytes();
-	byte[] newStuff = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes();
-
-	String readableStuffDelegate = "<me>";
-	static final Hash stuffDelegateHash = new Hash(new byte[] {
-			(byte)0xf0, (byte)0xe1, (byte)0xd2, (byte)0xc3,
-			(byte)0xf4, (byte)0xe5, (byte)0xd6, (byte)0xc7,
-			(byte)0xf8, (byte)0xe9, (byte)0xda, (byte)0xcb,
-			(byte)0xfc, (byte)0xed, (byte)0xde, (byte)0xcf,
-			(byte)0xf0, (byte)0xe1, (byte)0xd2, (byte)0xc3,
-			(byte)0xf4, (byte)0xe5, (byte)0xd6, (byte)0xc7,
-			(byte)0xf8, (byte)0xe9, (byte)0xda, (byte)0xcb,
-			(byte)0xfc, (byte)0xed, (byte)0xde, (byte)0xcf,
-			(byte)0xf0, (byte)0xe1, (byte)0xd2, (byte)0xc3,
-			(byte)0xf4, (byte)0xe5, (byte)0xd6, (byte)0xc7,
-			(byte)0xf8, (byte)0xe9, (byte)0xda, (byte)0xcb,
-			(byte)0xfc, (byte)0xed, (byte)0xde, (byte)0xcf,
-	});
-
-	BinaryObjectStore blobStore;
-	BinaryObject newDelegate;
-	BinaryObject stuffDelegate;
-	BinaryObject newStuffDelegate;
-
-	MerkleOptionalBlob subject;
-
-	@BeforeEach
-	public void setup() {
-		newDelegate = mock(BinaryObject.class);
-		stuffDelegate = mock(BinaryObject.class);
-		newStuffDelegate = mock(BinaryObject.class);
-		given(stuffDelegate.toString()).willReturn(readableStuffDelegate);
-		given(stuffDelegate.getHash()).willReturn(stuffDelegateHash);
-		blobStore = mock(BinaryObjectStore.class);
-		given(blobStore.put(argThat((byte[] bytes) -> Arrays.equals(bytes, stuff)))).willReturn(stuffDelegate);
-		given(blobStore.put(argThat((byte[] bytes) -> Arrays.equals(bytes, newStuff)))).willReturn(newStuffDelegate);
-		given(blobStore.get(stuffDelegate)).willReturn(stuff);
-
-		MerkleOptionalBlob.blobSupplier = () -> newDelegate;
-		MerkleOptionalBlob.blobStoreSupplier = () -> blobStore;
-
-		subject = new MerkleOptionalBlob(stuff);
-	}
-
-	@AfterEach
-	public void cleanup() {
-		MerkleOptionalBlob.blobSupplier = BinaryObject::new;
-		MerkleOptionalBlob.blobStoreSupplier = BinaryObjectStore::getInstance;
-	}
-
-	@Test
-	public void modifyWorksWithNonEmpty() {
-		// when:
-		subject.modify(newStuff);
-
-		// then:
-		verify(stuffDelegate).release();
-		// and:
-		assertEquals(newStuffDelegate, subject.getDelegate());
-	}
-
-	@Test
-	public void modifyWorksWithEmpty() {
-		// given:
-		subject = new MerkleOptionalBlob();
-
-		// when:
-		subject.modify(newStuff);
-
-		// then:
-		assertEquals(newStuffDelegate, subject.getDelegate());
-	}
-
-	@Test
-	public void getDataWorksWithStuff() {
-		// expect:
-		assertArrayEquals(stuff, subject.getData());
-	}
-
-	@Test
-	public void getDataWorksWithNoStuff() {
-		// expect:
-		assertArrayEquals(MerkleOptionalBlob.NO_DATA, new MerkleOptionalBlob().getData());
-	}
-
-	@Test
-	public void emptyHashAsExpected() {
-		// given:
-		var defaultSubject = new MerkleOptionalBlob();
-
-		// expect;
-		assertEquals(MerkleOptionalBlob.MISSING_DELEGATE_HASH, defaultSubject.getHash());
-	}
-
-	@Test
-	public void stuffHashDelegates() {
-		// expect;
-		assertEquals(stuffDelegateHash, subject.getHash());
-	}
-
-	@Test
-	public void merkleMethodsWork() {
-		// expect;
-		assertEquals(MerkleOptionalBlob.MERKLE_VERSION, subject.getVersion());
-		assertEquals(MerkleOptionalBlob.RUNTIME_CONSTRUCTABLE_ID, subject.getClassId());
-		assertTrue(subject.isLeaf());
-		assertThrows(UnsupportedOperationException.class, () -> subject.setHash(null));
-		assertDoesNotThrow(() -> subject.serializeAbbreviated(null));
-	}
-
-	@Test
-	public void deserializeWorksWithEmpty() throws IOException {
-		// setup:
-		var in = mock(SerializableDataInputStream.class);
-		// and:
-		var defaultSubject = new MerkleOptionalBlob();
-
-		given(in.readBoolean()).willReturn(false);
-
-		// when:
-		defaultSubject.deserialize(in, MerkleOptionalBlob.MERKLE_VERSION);
-
-		// then:
-		verify(newDelegate, never()).deserialize(in, MerkleOptionalBlob.MERKLE_VERSION);
-	}
-
-	@Test
-	public void serializeWorksWithEmpty() throws IOException {
-		// setup:
-		var out = mock(SerializableDataOutputStream.class);
-		// and:
-		var defaultSubject = new MerkleOptionalBlob();
-
-		// when:
-		defaultSubject.serialize(out);
-
-		// then:
-		verify(out).writeBoolean(false);
-	}
-
-	@Test
-	public void serializeWorksWithDelegate() throws IOException {
-		// setup:
-		var out = mock(SerializableDataOutputStream.class);
-		// and:
-		InOrder inOrder = inOrder(out, stuffDelegate);
-
-		// when:
-		subject.serialize(out);
-
-		// then:
-		inOrder.verify(out).writeBoolean(true);
-		inOrder.verify(stuffDelegate).serialize(out);
-	}
-
-	@Test
-	public void deserializeAbbrevWorksWithDelegate() {
-		// setup:
-		var in = mock(SerializableDataInputStream.class);
-
-		// when:
-		subject.deserializeAbbreviated(in, stuffDelegateHash, MerkleOptionalBlob.MERKLE_VERSION);
-
-		// then:
-		verify(newDelegate).deserializeAbbreviated(in, stuffDelegateHash, MerkleOptionalBlob.MERKLE_VERSION);
-	}
-
-	@Test
-	public void deserializeAbbrevWorksWithoutDelegate() {
-		// setup:
-		var in = mock(SerializableDataInputStream.class);
-
-		// when:
-		subject.deserializeAbbreviated(in, MerkleOptionalBlob.MISSING_DELEGATE_HASH, MerkleOptionalBlob.MERKLE_VERSION);
-
-		// then:
-		assertEquals(MerkleOptionalBlob.NO_DATA, subject.getData());
-		assertEquals(MerkleOptionalBlob.MISSING_DELEGATE, subject.getDelegate());
-	}
-
-	@Test
-	public void deserializeWorksWithDelegate() throws IOException {
-		// setup:
-		var in = mock(SerializableDataInputStream.class);
-		// and:
-		var defaultSubject = new MerkleOptionalBlob();
-
-		given(in.readBoolean()).willReturn(true);
-
-		// when:
-		defaultSubject.deserialize(in, MerkleOptionalBlob.MERKLE_VERSION);
-
-		// then:
-		verify(newDelegate).deserialize(in, MerkleOptionalBlob.MERKLE_VERSION);
-	}
-
-	@Test
-	public void toStringWorks() {
-		// expect:
-		assertEquals(
-				"MerkleOptionalBlob{delegate=" + readableStuffDelegate + "}",
-				subject.toString());
-		assertEquals(
-				"MerkleOptionalBlob{delegate=" + null + "}",
-				new MerkleOptionalBlob().toString());
-	}
-
-	@Test
-	public void copyWorks() {
-		given(stuffDelegate.copy()).willReturn(stuffDelegate);
-
-		// when:
-		var subjectCopy = subject.copy();
-
-		// then:
-		assertTrue(subjectCopy != subject);
-		assertEquals(subject, subjectCopy);
-	}
-
-	@Test
-	public void deleteDelegatesIfAppropos() {
-		// when:
-		subject.release();
-
-		// then:
-		verify(stuffDelegate).release();
-	}
-
-	@Test
-	public void doesntDelegateIfMissing() {
-		// given:
-		subject = new MerkleOptionalBlob();
-
-		// when:
-		subject.release();
-
-		// then:
-		verify(stuffDelegate, never()).release();
-	}
-
-	@Test
-	public void objectContractMet() {
-		// given:
-		var one = new MerkleOptionalBlob();
-		var two = new MerkleOptionalBlob(stuff);
-		var three = new MerkleOptionalBlob(stuff);
-		var four = new Object();
-
-		// then:
-		assertNotEquals(null, one);
-		assertNotEquals(four, one);
-		assertNotEquals(two, one);
-		assertEquals(one, one);
-		// and:
-		assertNotEquals(one.hashCode(), two.hashCode());
-		assertEquals(two.hashCode(), three.hashCode());
-	}
-}
+//package com.hedera.services.state.merkle;
+//
+///*-
+// * ‌
+// * Hedera Services Node
+// * ​
+// * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+// * ​
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *      http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// * ‍
+// */
+//
+//import com.swirlds.blob.BinaryObject;
+//import com.swirlds.blob.BinaryObjectStore;
+//import com.swirlds.common.crypto.Hash;
+//import com.swirlds.common.io.SerializableDataInputStream;
+//import com.swirlds.common.io.SerializableDataOutputStream;
+//import org.junit.jupiter.api.AfterEach;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.mockito.InOrder;
+//
+//import java.io.IOException;
+//import java.util.Arrays;
+//
+//import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+//import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+//import static org.junit.jupiter.api.Assertions.assertNotEquals;
+//import static org.junit.jupiter.api.Assertions.assertThrows;
+//import static org.junit.jupiter.api.Assertions.assertTrue;
+//import static org.mockito.BDDMockito.argThat;
+//import static org.mockito.BDDMockito.given;
+//import static org.mockito.BDDMockito.inOrder;
+//import static org.mockito.BDDMockito.mock;
+//import static org.mockito.BDDMockito.never;
+//import static org.mockito.BDDMockito.verify;
+//
+//class MerkleOptionalBlobTest {
+//	byte[] stuff = "abcdefghijklmnopqrstuvwxyz".getBytes();
+//	byte[] newStuff = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes();
+//
+//	String readableStuffDelegate = "<me>";
+//	static final Hash stuffDelegateHash = new Hash(new byte[] {
+//			(byte)0xf0, (byte)0xe1, (byte)0xd2, (byte)0xc3,
+//			(byte)0xf4, (byte)0xe5, (byte)0xd6, (byte)0xc7,
+//			(byte)0xf8, (byte)0xe9, (byte)0xda, (byte)0xcb,
+//			(byte)0xfc, (byte)0xed, (byte)0xde, (byte)0xcf,
+//			(byte)0xf0, (byte)0xe1, (byte)0xd2, (byte)0xc3,
+//			(byte)0xf4, (byte)0xe5, (byte)0xd6, (byte)0xc7,
+//			(byte)0xf8, (byte)0xe9, (byte)0xda, (byte)0xcb,
+//			(byte)0xfc, (byte)0xed, (byte)0xde, (byte)0xcf,
+//			(byte)0xf0, (byte)0xe1, (byte)0xd2, (byte)0xc3,
+//			(byte)0xf4, (byte)0xe5, (byte)0xd6, (byte)0xc7,
+//			(byte)0xf8, (byte)0xe9, (byte)0xda, (byte)0xcb,
+//			(byte)0xfc, (byte)0xed, (byte)0xde, (byte)0xcf,
+//	});
+//
+//	BinaryObjectStore blobStore;
+//	BinaryObject newDelegate;
+//	BinaryObject stuffDelegate;
+//	BinaryObject newStuffDelegate;
+//
+//	MerkleOptionalBlob subject;
+//
+//	@BeforeEach
+//	public void setup() {
+//		newDelegate = mock(BinaryObject.class);
+//		stuffDelegate = mock(BinaryObject.class);
+//		newStuffDelegate = mock(BinaryObject.class);
+//		given(stuffDelegate.toString()).willReturn(readableStuffDelegate);
+//		given(stuffDelegate.getHash()).willReturn(stuffDelegateHash);
+//		blobStore = mock(BinaryObjectStore.class);
+//		given(blobStore.put(argThat((byte[] bytes) -> Arrays.equals(bytes, stuff)))).willReturn(stuffDelegate);
+//		given(blobStore.put(argThat((byte[] bytes) -> Arrays.equals(bytes, newStuff)))).willReturn(newStuffDelegate);
+//		given(blobStore.get(stuffDelegate)).willReturn(stuff);
+//
+//		MerkleOptionalBlob.blobSupplier = () -> newDelegate;
+//		MerkleOptionalBlob.blobStoreSupplier = () -> blobStore;
+//
+//		subject = new MerkleOptionalBlob(stuff);
+//	}
+//
+//	@AfterEach
+//	public void cleanup() {
+//		MerkleOptionalBlob.blobSupplier = BinaryObject::new;
+//		MerkleOptionalBlob.blobStoreSupplier = BinaryObjectStore::getInstance;
+//	}
+//
+//	@Test
+//	public void modifyWorksWithNonEmpty() {
+//		// when:
+//		subject.modify(newStuff);
+//
+//		// then:
+//		verify(stuffDelegate).release();
+//		// and:
+//		assertEquals(newStuffDelegate, subject.getDelegate());
+//	}
+//
+//	@Test
+//	public void modifyWorksWithEmpty() {
+//		// given:
+//		subject = new MerkleOptionalBlob();
+//
+//		// when:
+//		subject.modify(newStuff);
+//
+//		// then:
+//		assertEquals(newStuffDelegate, subject.getDelegate());
+//	}
+//
+//	@Test
+//	public void getDataWorksWithStuff() {
+//		// expect:
+//		assertArrayEquals(stuff, subject.getData());
+//	}
+//
+//	@Test
+//	public void getDataWorksWithNoStuff() {
+//		// expect:
+//		assertArrayEquals(MerkleOptionalBlob.NO_DATA, new MerkleOptionalBlob().getData());
+//	}
+//
+//	@Test
+//	public void emptyHashAsExpected() {
+//		// given:
+//		var defaultSubject = new MerkleOptionalBlob();
+//
+//		// expect;
+//		assertEquals(MerkleOptionalBlob.MISSING_DELEGATE_HASH, defaultSubject.getHash());
+//	}
+//
+//	@Test
+//	public void stuffHashDelegates() {
+//		// expect;
+//		assertEquals(stuffDelegateHash, subject.getHash());
+//	}
+//
+//	@Test
+//	public void merkleMethodsWork() {
+//		// expect;
+//		assertEquals(MerkleOptionalBlob.MERKLE_VERSION, subject.getVersion());
+//		assertEquals(MerkleOptionalBlob.RUNTIME_CONSTRUCTABLE_ID, subject.getClassId());
+//		assertTrue(subject.isLeaf());
+//		assertThrows(UnsupportedOperationException.class, () -> subject.setHash(null));
+//		assertDoesNotThrow(() -> subject.serializeAbbreviated(null));
+//	}
+//
+//	@Test
+//	public void deserializeWorksWithEmpty() throws IOException {
+//		// setup:
+//		var in = mock(SerializableDataInputStream.class);
+//		// and:
+//		var defaultSubject = new MerkleOptionalBlob();
+//
+//		given(in.readBoolean()).willReturn(false);
+//
+//		// when:
+//		defaultSubject.deserialize(in, MerkleOptionalBlob.MERKLE_VERSION);
+//
+//		// then:
+//		verify(newDelegate, never()).deserialize(in, MerkleOptionalBlob.MERKLE_VERSION);
+//	}
+//
+//	@Test
+//	public void serializeWorksWithEmpty() throws IOException {
+//		// setup:
+//		var out = mock(SerializableDataOutputStream.class);
+//		// and:
+//		var defaultSubject = new MerkleOptionalBlob();
+//
+//		// when:
+//		defaultSubject.serialize(out);
+//
+//		// then:
+//		verify(out).writeBoolean(false);
+//	}
+//
+//	@Test
+//	public void serializeWorksWithDelegate() throws IOException {
+//		// setup:
+//		var out = mock(SerializableDataOutputStream.class);
+//		// and:
+//		InOrder inOrder = inOrder(out, stuffDelegate);
+//
+//		// when:
+//		subject.serialize(out);
+//
+//		// then:
+//		inOrder.verify(out).writeBoolean(true);
+//		inOrder.verify(stuffDelegate).serialize(out);
+//	}
+//
+//	@Test
+//	public void deserializeAbbrevWorksWithDelegate() {
+//		// setup:
+//		var in = mock(SerializableDataInputStream.class);
+//
+//		// when:
+//		subject.deserializeAbbreviated(in, stuffDelegateHash, MerkleOptionalBlob.MERKLE_VERSION);
+//
+//		// then:
+//		verify(newDelegate).deserializeAbbreviated(in, stuffDelegateHash, MerkleOptionalBlob.MERKLE_VERSION);
+//	}
+//
+//	@Test
+//	public void deserializeAbbrevWorksWithoutDelegate() {
+//		// setup:
+//		var in = mock(SerializableDataInputStream.class);
+//
+//		// when:
+//		subject.deserializeAbbreviated(in, MerkleOptionalBlob.MISSING_DELEGATE_HASH, MerkleOptionalBlob.MERKLE_VERSION);
+//
+//		// then:
+//		assertEquals(MerkleOptionalBlob.NO_DATA, subject.getData());
+//		assertEquals(MerkleOptionalBlob.MISSING_DELEGATE, subject.getDelegate());
+//	}
+//
+//	@Test
+//	public void deserializeWorksWithDelegate() throws IOException {
+//		// setup:
+//		var in = mock(SerializableDataInputStream.class);
+//		// and:
+//		var defaultSubject = new MerkleOptionalBlob();
+//
+//		given(in.readBoolean()).willReturn(true);
+//
+//		// when:
+//		defaultSubject.deserialize(in, MerkleOptionalBlob.MERKLE_VERSION);
+//
+//		// then:
+//		verify(newDelegate).deserialize(in, MerkleOptionalBlob.MERKLE_VERSION);
+//	}
+//
+//	@Test
+//	public void toStringWorks() {
+//		// expect:
+//		assertEquals(
+//				"MerkleOptionalBlob{delegate=" + readableStuffDelegate + "}",
+//				subject.toString());
+//		assertEquals(
+//				"MerkleOptionalBlob{delegate=" + null + "}",
+//				new MerkleOptionalBlob().toString());
+//	}
+//
+//	@Test
+//	public void copyWorks() {
+//		given(stuffDelegate.copy()).willReturn(stuffDelegate);
+//
+//		// when:
+//		var subjectCopy = subject.copy();
+//
+//		// then:
+//		assertTrue(subjectCopy != subject);
+//		assertEquals(subject, subjectCopy);
+//	}
+//
+//	@Test
+//	public void deleteDelegatesIfAppropos() {
+//		// when:
+//		subject.release();
+//
+//		// then:
+//		verify(stuffDelegate).release();
+//	}
+//
+//	@Test
+//	public void doesntDelegateIfMissing() {
+//		// given:
+//		subject = new MerkleOptionalBlob();
+//
+//		// when:
+//		subject.release();
+//
+//		// then:
+//		verify(stuffDelegate, never()).release();
+//	}
+//
+//	@Test
+//	public void objectContractMet() {
+//		// given:
+//		var one = new MerkleOptionalBlob();
+//		var two = new MerkleOptionalBlob(stuff);
+//		var three = new MerkleOptionalBlob(stuff);
+//		var four = new Object();
+//
+//		// then:
+//		assertNotEquals(null, one);
+//		assertNotEquals(four, one);
+//		assertNotEquals(two, one);
+//		assertEquals(one, one);
+//		// and:
+//		assertNotEquals(one.hashCode(), two.hashCode());
+//		assertEquals(two.hashCode(), three.hashCode());
+//	}
+//}

--- a/hedera-node/src/test/java/com/hedera/test/forensics/domain/PojoFile.java
+++ b/hedera-node/src/test/java/com/hedera/test/forensics/domain/PojoFile.java
@@ -46,8 +46,8 @@ public class PojoFile {
 	public static PojoFile from(MerkleBlobMeta sk, MerkleOptionalBlob value) {
 		var pojo = new PojoFile();
 		pojo.setPath(sk.getPath());
-		pojo.setBlobHash(value.getDelegate().getHash().toString());
-		pojo.setBlobDeleted(value.getDelegate().isReleased());
+		pojo.setBlobHash(value.getBlobHash().toString());
+		pojo.setBlobDeleted(value.isReleased());
 		return pojo;
 	}
 


### PR DESCRIPTION
Signed-off-by: Daniel Ivanov <daniel.k.ivanov95@gmail.com>

**Summary of the change**:
Refactors MerkleOptionalBlob to use FileBlobs instead of Postgres blobs
